### PR TITLE
Fix shapes translated not having correct center of mass and inertia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.119"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-default = ["single-dim3", "serde-serialize"]
+default = ["single-dim2", "serde-serialize"]
 dim2 = []
 dim3 = []
 single = []

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The reason it was rewritten is to do easier cross platform determinism part and 
 - Liquids Missing.
 - No support for asymetric collisions (eg. object 1 hitting object 2 but object 2 not hitting object 1). More info here [Rapier Collision groups and solver groups](https://rapier.rs/docs/user_guides/rust/colliders/#collision-groups-and-solver-groups). This is the exact check rapier does: `(A.layer & B.mask) != 0 && (B.layer & A.mask) != 0`
 - Friction works differently than it does in Godot. The current formula is: friction is multiplied by other friction, bounce is taken the max value.
+- Setting Center of Mass to Custom doesn't work right now.
 
 # Platforms
 

--- a/src/rapier_wrapper/collider.rs
+++ b/src/rapier_wrapper/collider.rs
@@ -27,7 +27,8 @@ fn skew_polyline(vertices: &Vec<Point<Real>>, skew: Real) -> SharedShape {
 // Function to skew a shape
 #[cfg(feature = "dim2")]
 pub fn skew_shape(shape: &SharedShape, skew: Real) -> SharedShape {
-    if skew == 0.0 {
+    use godot::builtin::math::FloatExt;
+    if skew.is_zero_approx() {
         return shape.clone();
     }
     match shape.shape_type() {
@@ -268,7 +269,7 @@ impl PhysicsEngine {
             }
             collider.set_friction_combine_rule(CoefficientCombineRule::Multiply);
             collider.set_restitution_combine_rule(CoefficientCombineRule::Max);
-            collider.set_density(0.0);
+            collider.set_density(1.0);
             collider.set_collision_groups(InteractionGroups {
                 memberships: Group::from(mat.collision_layer),
                 filter: Group::from(mat.collision_mask),


### PR DESCRIPTION
In Godot center of mass, inertia and mass is per the whole body, not per shape.
In Rapier it is per shape. Instead calculate the shape's mass and inertia in Rapier and multiply such that the whole mass equals the one of the body.
Limitations:
Doesn't support center of body change, since we work with center of shapes.