### PR TITLE
Update readme and disable parallel builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,6 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "parry2d",
- "rayon",
  "rustc-hash",
  "serde",
  "simba",
@@ -722,7 +721,6 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "parry2d-f64",
- "rayon",
  "rustc-hash",
  "serde",
  "simba",
@@ -748,7 +746,6 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "parry3d",
- "rayon",
  "rustc-hash",
  "serde",
  "simba",
@@ -774,7 +771,6 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "parry3d-f64",
- "rayon",
  "rustc-hash",
  "serde",
  "simba",
@@ -787,26 +783,6 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ serde-serialize = ["serde", "hashbrown/serde", "bincode", "serde_json", "typetag
 simd-stable = ["rapier2d/simd-stable", "rapier2d-f64/simd-stable", "rapier3d/simd-stable", "rapier3d-f64/simd-stable"]
 simd-nightly = ["rapier2d/simd-nightly", "rapier2d-f64/simd-nightly", "rapier3d/simd-nightly", "rapier3d-f64/simd-nightly"]
 wasm-bindgen = ["rapier2d/wasm-bindgen", "rapier2d-f64/wasm-bindgen", "rapier3d/wasm-bindgen", "rapier3d-f64/wasm-bindgen"]
-parallel = ["rapier2d/parallel", "rapier2d-f64/parallel", "rapier3d/parallel", "rapier3d-f64/parallel"]
+#parallel = ["rapier2d/parallel", "rapier2d-f64/parallel", "rapier3d/parallel", "rapier3d-f64/parallel"]
+parallel = []
 experimental-wasm = ["godot/experimental-wasm", "godot/lazy-function-tables"]
 single-dim2 = ["single", "dim2", "rapier2d", "salva2d"]
 double-dim2 = ["double", "dim2", "rapier2d-f64", "salva2d"]
 single-dim3 = ["single", "dim3", "rapier3d", "salva3d"]
 double-dim3 = ["double", "dim3", "rapier3d-f64", "salva3d"]
-
 
 [dependencies]
 bincode = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -27,16 +27,19 @@ Godot Rapier Physics is a 2D and 3D physics drop-in replacement for the [Godot g
 
 # Performance
 
-Creating objects until FPS drops below 30. Running on a macbook m2 pro. Everything is run inside the godot editor using the [Godot Physics Tests](https://github.com/fabriceci/Godot-Physics-Tests) repository.
+Creating objects until FPS drops below 30. Running on a macbook m2 pro with Godot 4.2. Everything is run inside the godot editor using the [Godot Physics Tests](https://github.com/fabriceci/Godot-Physics-Tests) repository.
 
 Each cell shows max shape count. Higher number is better.
 
 Shape|Godot 2D|Godot 3D|Rapier 2D (C++)|Rapier 2D (Rust)|Rapier 3D (Rust)|Jolt 3D
 -|-|-|-|-|-|-
-Sphere|5000|3300|8800|5000|4200|8000
-Box|3500|3200|7700|4500|4000|7200
-Capsule|4500|2700|8000|4500|3700|7400
-Convex Polygon|3500|3100|6500|4000|4000|8000
+Sphere|5000|3300|8800|6200|4200|8000
+Box|3500|3200|7700|5800|4000|7200
+Capsule|4500|2700|8000|5800|3700|7400
+Convex Polygon|3500|3100|6500|4800|4000|8000
+
+TODO run pyramid and joints tests.
+
 
 # Note
 


### PR DESCRIPTION
I am unsure if it brings any speedup right now, and on 2d there is a great increase without threads. So disabling parallel builds for now until I debug more.