### PR TITLE
Fix area bug crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ double-dim3 = ["double", "dim3", "rapier3d-f64", "salva3d"]
 bincode = { version = "1", optional = true }
 hashbrown = { version = "0.14" }
 
-godot = { git = "https://github.com/ughuuu/gdext", branch = "make-stuff-serializable", features=["lazy-function-tables", "api-4-2"] }
+godot = { git = "https://github.com/ughuuu/gdext", branch = "make-stuff-serializable", features=["api-4-2"] }
+#godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features=["api-4-2"] }
 
 rapier2d = { version = "0.21", optional = true }
 rapier2d-f64 = { version = "0.21", optional = true}

--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -379,7 +379,7 @@ impl RapierArea {
             space.area_remove_from_area_update_list(*area_rid);
         }
         for (detected_body, _) in &detected_bodies {
-            RapierBody::apply_area_orverride_to_body(
+            RapierBody::apply_area_override_to_body(
                 detected_body,
                 physics_engine,
                 physics_spaces,

--- a/src/bodies/rapier_body.rs
+++ b/src/bodies/rapier_body.rs
@@ -468,7 +468,7 @@ impl RapierBody {
             let area_rid = p_area.get_base().get_rid();
             let priority = p_area.get_priority();
             self.areas.push(RidWithPriority::new(area_rid, priority));
-            self.areas.sort_by(|a, b| b.priority.cmp(&a.priority));
+            self.areas.sort_by(|a, b| a.priority.cmp(&b.priority));
             self.on_area_updated(area_rid, space);
         }
     }

--- a/src/bodies/rapier_body.rs
+++ b/src/bodies/rapier_body.rs
@@ -2090,7 +2090,6 @@ impl IRapierCollisionObject for RapierBody {
 impl Drop for RapierBody {
     fn drop(&mut self) {
         if let Some(direct_state) = &self.direct_state {
-            // TODO
             direct_state.clone().free();
         }
     }

--- a/src/servers/rapier_physics_server_impl.rs
+++ b/src/servers/rapier_physics_server_impl.rs
@@ -601,7 +601,7 @@ impl RapierPhysicsServerImpl {
                 &mut self.physics_data.spaces,
             );
         }
-        RapierBody::apply_area_orverride_to_body(
+        RapierBody::apply_area_override_to_body(
             &body,
             &mut self.physics_data.physics_engine,
             &mut self.physics_data.spaces,
@@ -1181,7 +1181,7 @@ impl RapierPhysicsServerImpl {
                 body.set_omit_force_integration(enable);
             }
         }
-        RapierBody::apply_area_orverride_to_body(
+        RapierBody::apply_area_override_to_body(
             &body,
             &mut self.physics_data.physics_engine,
             &mut self.physics_data.spaces,

--- a/src/spaces/rapier_space.rs
+++ b/src/spaces/rapier_space.rs
@@ -302,7 +302,7 @@ impl RapierSpace {
         }
         space.reset_mass_properties_update_list();
         for body in &body_area_update_list {
-            RapierBody::apply_area_orverride_to_body(
+            RapierBody::apply_area_override_to_body(
                 body,
                 &mut physics_data.physics_engine,
                 &mut physics_data.spaces,

--- a/src/spaces/rapier_space.rs
+++ b/src/spaces/rapier_space.rs
@@ -310,6 +310,13 @@ impl RapierSpace {
             );
         }
         for body in gravity_update_list {
+            // first update the area override
+            RapierBody::apply_area_override_to_body(
+                &body,
+                &mut physics_data.physics_engine,
+                &mut physics_data.spaces,
+                &mut physics_data.collision_objects,
+            );
             if let Some(body) = physics_data.collision_objects.get_mut(&body)
                 && let Some(body) = body.get_mut_body()
             {


### PR DESCRIPTION
Crash happens because of the use of .to() in code. Should probably remove all these with try_to() soon. Though in this case it's good it crashed because i found out I was converting to the wrong type. And this value should anyway always be of type Vector2(for gravity_vector)