### PR TITLE
Fix area mask/layer issue

### DIFF
--- a/src/rapier_wrapper/collider.rs
+++ b/src/rapier_wrapper/collider.rs
@@ -343,7 +343,7 @@ impl PhysicsEngine {
             // less data to serialize
             collider.set_collision_groups(InteractionGroups {
                 memberships: Group::from(mat.collision_layer),
-                filter: Group::from(mat.collision_layer),
+                filter: Group::from(mat.collision_mask),
             });
             collider.set_solver_groups(InteractionGroups {
                 memberships: Group::GROUP_1,


### PR DESCRIPTION
Areas were using layer for both membership and filter. It was not using mask at all.