### PR TITLE
Fix owner leak in `destroy_shape()`

### DIFF
--- a/src/shapes/rapier_shape_base.rs
+++ b/src/shapes/rapier_shape_base.rs
@@ -120,6 +120,7 @@ impl RapierShapeBase {
 
     pub fn destroy_shape(&mut self, physics_engine: &mut PhysicsEngine) {
         physics_engine.shape_destroy(self.get_id());
+        self.state.owners.clear();
     }
 
     #[cfg(feature = "serde-serialize")]


### PR DESCRIPTION
Ensures that lingering owner references are cleared after a shape is destroyed by adding a call to `clear()` on the `owners` HashMap.

Fixes #266.
