### PR TITLE
Add motor position targeting and fix HingeJoint3D axis bug

### DIFF
--- a/bin2d/addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd
+++ b/bin2d/addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd
@@ -32,40 +32,38 @@ extends PinJoint2D
 @export_range(0.0, 100.0, 0.01) var ik_damping: float = 1.0:
 	set(value):
 		ik_damping = value
-		if is_inside_tree():
-			_update_ik_options()
+		_update_ik_options()
 
 @export_range(1, 100, 1) var ik_max_iterations: int = 10:
 	set(value):
 		ik_max_iterations = value
-		if is_inside_tree():
-			_update_ik_options()
+		_update_ik_options()
 
-@export_group("Motor Position Targeting")
 
-@export var enable: bool = false:
+@export_group("Motor Position", "motor_position_")
+## Motor Position Targeting acts like a spring to pull the joint
+## back to the target angle
+@export_custom(PROPERTY_HINT_GROUP_ENABLE, "") var motor_position_enabled: bool = false:
 	set(value):
-		enable = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_position_enabled = value
+		_update_motor_position_options()
 
-@export var target_angle: float = 0.0:
+@export_range(-180, 180, 0.1, "radians_as_degrees") var motor_position_target_angle: float = 0.0:
 	set(value):
-		target_angle = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_position_target_angle = value
+		_update_motor_position_options()
 
-@export var stiffness: float = 0.0:
+@export var motor_position_stiffness: float = 0.0:
 	set(value):
-		stiffness = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_position_stiffness = value
+		_update_motor_position_options()
 
-@export var damping: float = 0.0:
+@export var motor_position_damping: float = 0.0:
 	set(value):
-		damping = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_position_damping = value
+		_update_motor_position_options()
+
+@export_group("","")
 
 var _ik_constrained_axes: int = 3
 
@@ -96,6 +94,7 @@ func _update_ik_options() -> void:
 	
 	var joint_rid := get_rid()
 	if not joint_rid.is_valid():
+		push_error("Invalid joint rid")
 		return
 	
 	RapierPhysicsServer2D.joint_set_ik_options(
@@ -114,14 +113,20 @@ func _update_motor_position_options() -> void:
 	
 	var joint_rid := get_rid()
 	if not joint_rid.is_valid():
+		push_error("Invalid joint rid")
 		return
-	
+		
+	# workaround what seems like a rapier issue
+	# stiffness of 0.0 behaves strangely
+	# expected behaviour is for joint to hang freely
+	if is_zero_approx(motor_position_stiffness):
+		motor_position_stiffness = 0.00001
 	RapierPhysicsServer2D.joint_set_motor_position_options(
 		joint_rid,
-		target_angle,
-		stiffness,
-		damping,
-		enable,
+		motor_position_target_angle,
+		motor_position_stiffness,
+		motor_position_damping,
+		motor_position_enabled,
 	)
 
 

--- a/bin2d/addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd
+++ b/bin2d/addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd
@@ -41,6 +41,32 @@ extends PinJoint2D
 		if is_inside_tree():
 			_update_ik_options()
 
+@export_group("Motor Position Targeting")
+
+@export var enable: bool = false:
+	set(value):
+		enable = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+@export var target_angle: float = 0.0:
+	set(value):
+		target_angle = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+@export var stiffness: float = 0.0:
+	set(value):
+		stiffness = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+@export var damping: float = 0.0:
+	set(value):
+		damping = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
 var _ik_constrained_axes: int = 3
 
 
@@ -50,6 +76,7 @@ func _init() -> void:
 func _ready() -> void:
 	_update_constrained_axes()
 	_update_ik_options()
+	_update_motor_position_options()
 
 func _physics_process(delta: float) -> void:
 	_solve_ik_for_target()
@@ -79,6 +106,24 @@ func _update_ik_options() -> void:
 		0.001,
 		0.001,
 	)
+
+
+func _update_motor_position_options() -> void:
+	if not is_inside_tree():
+		return
+	
+	var joint_rid := get_rid()
+	if not joint_rid.is_valid():
+		return
+	
+	RapierPhysicsServer2D.joint_set_motor_position_options(
+		joint_rid,
+		target_angle,
+		stiffness,
+		damping,
+		enable,
+	)
+
 
 func _update_constrained_axes() -> void:
 	_ik_constrained_axes = 0

--- a/bin2d/test_motor_position.gd
+++ b/bin2d/test_motor_position.gd
@@ -1,0 +1,16 @@
+extends Node2D
+
+@onready var beam := %CantileveredBeam as StaticBody2D
+@onready var lever_joint := %RapierPinJoint2D as RapierPinJoint2D
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+func _process(_delta: float)	->void:
+	if Input.is_action_just_pressed("ui_accept"):
+		for node in beam.get_children():
+			var pj := node as RapierPinJoint2D
+			if pj:
+				pj.motor_position_enabled = not pj.motor_position_enabled
+		lever_joint.motor_position_enabled = not lever_joint.motor_position_enabled	

--- a/bin2d/test_motor_position.gd.uid
+++ b/bin2d/test_motor_position.gd.uid
@@ -1,0 +1,1 @@
+uid://de4wf7wb5aule

--- a/bin2d/test_motor_position.tscn
+++ b/bin2d/test_motor_position.tscn
@@ -1,0 +1,75 @@
+[gd_scene format=3 uid="uid://dufpjbflrebmt"]
+
+[ext_resource type="Script" uid="uid://de4wf7wb5aule" path="res://test_motor_position.gd" id="1_airgf"]
+[ext_resource type="Script" uid="uid://ch4e8om5vmkgs" path="res://test_motor_position_beam.gd" id="1_i7gvn"]
+[ext_resource type="Script" uid="uid://unwhnooi7g2c" path="res://addons/godot-rapier2d/custom_nodes/rapier_rigid_body_2d.gd" id="2_airgf"]
+[ext_resource type="Script" uid="uid://bjckrk4dmnguh" path="res://test_motor_position_spawner.gd" id="3_qmxtd"]
+[ext_resource type="Script" uid="uid://bv2bc4lt5v7hu" path="res://addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd" id="4_dnnds"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_rl7rh"]
+size = Vector2(0, 0)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qx5oi"]
+size = Vector2(200, 20)
+
+[node name="TestMotorPosition" type="Node2D" unique_id=1327340147]
+script = ExtResource("1_airgf")
+
+[node name="Label" type="Label" parent="." unique_id=300206132]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 356.0
+offset_bottom = 23.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Press space to toggle motor position targeting"
+
+[node name="CantileveredBeam" type="StaticBody2D" parent="." unique_id=1315170967]
+unique_name_in_owner = true
+position = Vector2(129, 259)
+collision_layer = 0
+collision_mask = 0
+script = ExtResource("1_i7gvn")
+number_of_segments = 6
+starting_segment_height = 30.0
+starting_segment_mass = 2.0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CantileveredBeam" unique_id=799502497]
+shape = SubResource("RectangleShape2D_rl7rh")
+
+[node name="CircleSpawner" type="Node2D" parent="." unique_id=848283850]
+position = Vector2(414, -65)
+script = ExtResource("3_qmxtd")
+
+[node name="SpawnTimer" type="Timer" parent="CircleSpawner" unique_id=1206903970]
+wait_time = 2.0
+autostart = true
+
+[node name="Lever" type="Node2D" parent="." unique_id=15142854]
+
+[node name="RapierPinJoint2D" type="PinJoint2D" parent="Lever" unique_id=1576361335]
+unique_name_in_owner = true
+position = Vector2(748, 505)
+node_a = NodePath("../../CantileveredBeam")
+node_b = NodePath("../RapierRigidBody2D")
+angular_limit_lower = -0.7853982
+angular_limit_upper = 0.7853982
+motor_target_velocity = 1.5707964
+script = ExtResource("4_dnnds")
+motor_position_enabled = true
+motor_position_target_angle = -0.6492624817418904
+motor_position_stiffness = 1000.0
+motor_position_damping = 10.0
+metadata/_custom_type_script = "uid://bv2bc4lt5v7hu"
+
+[node name="RapierRigidBody2D" type="RigidBody2D" parent="Lever" unique_id=1189770906]
+position = Vector2(776, 507)
+script = ExtResource("2_airgf")
+metadata/_custom_type_script = "uid://unwhnooi7g2c"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Lever/RapierRigidBody2D" unique_id=14000119]
+shape = SubResource("RectangleShape2D_qx5oi")
+
+[connection signal="timeout" from="CircleSpawner/SpawnTimer" to="CircleSpawner" method="_on_spawn_timer_timeout"]

--- a/bin2d/test_motor_position_beam.gd
+++ b/bin2d/test_motor_position_beam.gd
@@ -1,0 +1,61 @@
+# Example of using RapierPinJoint2D motor position features 
+# to simulate a cantilever beam
+extends StaticBody2D
+
+@export var number_of_segments : int = 10	
+@export var starting_stiffness: float = 100000.0
+@export var damping : float = 500.0
+@export var segment_length : float = 100.0
+@export var starting_segment_height : float = 50.0
+@export var starting_segment_mass : float = 1.0
+@export_range(0.5,1.0) var segment_narrowing_factor : float = 0.9
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	var rb : RigidBody2D
+	var cs : CollisionShape2D
+	var sp : RectangleShape2D
+	var pj : RapierPinJoint2D
+	
+	var height := starting_segment_height
+	var mass := starting_segment_mass
+	var last_path := get_path()
+	var originx := 0.0
+	
+	for i in range(number_of_segments):
+		rb = RigidBody2D.new()
+		cs = CollisionShape2D.new()
+		sp = RectangleShape2D.new()
+		sp.size.x = segment_length
+		sp.size.y = height
+		cs.shape = sp
+		rb.transform.origin.x = originx + segment_length*0.5
+		rb.mass = mass
+		rb.add_child(cs)
+		add_child(rb)
+
+		pj = RapierPinJoint2D.new()
+		pj.node_a = last_path
+		last_path = rb.get_path()
+		pj.node_b = last_path
+		
+		# Check physics texts for correct stiffness proportionality
+		# It's just a workable guess that angular stiffness should reduce 
+		# proportional to beam height. 
+		pj.motor_position_stiffness = starting_stiffness * height / starting_segment_height
+		pj.motor_position_damping = damping
+		pj.motor_position_target_angle = deg_to_rad(0.0)
+		pj.motor_position_enabled = true
+		pj.transform.origin.x = originx
+		
+		# joint_type = 0 - Impulse
+		# joint_type = 1 - Multibody
+		# joint_type = 2 - Multibody Kinematic
+		# Multibody acheives a better result in this case
+		pj.joint_type = 0 
+		add_child(pj)
+		
+		height = height * segment_narrowing_factor
+		mass = mass * segment_narrowing_factor * segment_narrowing_factor
+		originx += segment_length
+			

--- a/bin2d/test_motor_position_beam.gd.uid
+++ b/bin2d/test_motor_position_beam.gd.uid
@@ -1,0 +1,1 @@
+uid://ch4e8om5vmkgs

--- a/bin2d/test_motor_position_spawner.gd
+++ b/bin2d/test_motor_position_spawner.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+@export var mass : float = 1.0
+
+func spawn_circle_body()->void:		
+	var rb := RigidBody2D.new()
+	var cs := CollisionShape2D.new()
+	var sp := CircleShape2D.new()
+	var vn := VisibleOnScreenNotifier2D.new()
+	sp.radius = 10.0	 * randf_range(0.5, 3.0)
+	cs.shape = sp
+	
+	rb.mass = mass * (sp.radius / 20.0) ** 3
+	rb.transform.origin.x = randf_range(-200.0, 200.0)
+	rb.add_child(cs)
+	rb.add_child(vn)
+	add_child(rb)	
+	vn.screen_exited.connect(_on_screen_exited.bind(rb))
+
+func _on_screen_exited(rb: RigidBody2D)->void:	
+	rb.queue_free()
+	
+func _on_spawn_timer_timeout() -> void:
+	spawn_circle_body()

--- a/bin2d/test_motor_position_spawner.gd.uid
+++ b/bin2d/test_motor_position_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://bjckrk4dmnguh

--- a/bin3d/addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd
+++ b/bin3d/addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd
@@ -53,6 +53,35 @@ extends HingeJoint3D
 		if is_inside_tree():
 			_update_ik_options()
 
+@export_group("Motor Position Targeting")
+
+@export var enable: bool = false:
+	set(value):
+		enable = value
+		if is_inside_tree():
+			_update_motor_position_options()
+# 		future @tool functionalit
+#		notify_property_list_changed()
+
+@export var target_angle: float = 0.0:
+	set(value):
+		target_angle = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+@export var stiffness: float = 0.0:
+	set(value):
+		stiffness = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+@export var damping: float = 0.0:
+	set(value):
+		damping = value
+		if is_inside_tree():
+			_update_motor_position_options()
+
+
 var _ik_constrained_axes: int = 7
 
 
@@ -62,6 +91,7 @@ func _init() -> void:
 func _ready() -> void:
 	_update_constrained_axes()
 	_update_ik_options()
+	_update_motor_position_options()
 
 func _physics_process(delta: float) -> void:
 	_solve_ik_for_target()
@@ -90,6 +120,22 @@ func _update_ik_options() -> void:
 		_ik_constrained_axes,
 		0.001,
 		0.001,
+	)
+
+func _update_motor_position_options() -> void:
+	if not is_inside_tree():
+		return
+	
+	var joint_rid := get_rid()
+	if not joint_rid.is_valid():
+		return
+	
+	RapierPhysicsServer3D.joint_set_motor_position_options(
+		joint_rid,
+		target_angle,
+		stiffness,
+		damping,
+		enable,
 	)
 
 func _update_constrained_axes() -> void:

--- a/bin3d/addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd
+++ b/bin3d/addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd
@@ -44,42 +44,37 @@ extends HingeJoint3D
 @export_range(0.0, 100.0, 0.01) var ik_damping: float = 1.0:
 	set(value):
 		ik_damping = value
-		if is_inside_tree():
-			_update_ik_options()
+		_update_ik_options()
 
 @export_range(1, 100, 1) var ik_max_iterations: int = 10:
 	set(value):
 		ik_max_iterations = value
-		if is_inside_tree():
-			_update_ik_options()
+		_update_ik_options()
 
-@export_group("Motor Position Targeting")
-
-@export var enable: bool = false:
+@export_group("Motor Position", "motor_")
+## Motor Position Targeting acts like a spring to pull the joint
+## back to the target angle
+@export_custom(PROPERTY_HINT_GROUP_ENABLE, "") var motor_position_enabled: bool = false:
 	set(value):
-		enable = value
-		if is_inside_tree():
-			_update_motor_position_options()
-# 		future @tool functionalit
-#		notify_property_list_changed()
+		motor_position_enabled = value
+		_update_motor_position_options()
 
-@export var target_angle: float = 0.0:
+@export_range(-180, 180, 0.1, "radians_as_degrees") var motor_target_angle: float = 0.0:
 	set(value):
-		target_angle = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_target_angle = value
+		_update_motor_position_options()
 
-@export var stiffness: float = 0.0:
+@export var motor_stiffness: float = 0.0:
 	set(value):
-		stiffness = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_stiffness = value
+		_update_motor_position_options()
 
-@export var damping: float = 0.0:
+@export var motor_damping: float = 0.0:
 	set(value):
-		damping = value
-		if is_inside_tree():
-			_update_motor_position_options()
+		motor_damping = value
+		_update_motor_position_options()
+
+@export_group("","")
 
 
 var _ik_constrained_axes: int = 7
@@ -92,7 +87,7 @@ func _ready() -> void:
 	_update_constrained_axes()
 	_update_ik_options()
 	_update_motor_position_options()
-
+	
 func _physics_process(delta: float) -> void:
 	_solve_ik_for_target()
 
@@ -111,6 +106,7 @@ func _update_ik_options() -> void:
 	
 	var joint_rid := get_rid()
 	if not joint_rid.is_valid():
+		push_error("Invalid joint rid")
 		return
 	
 	RapierPhysicsServer3D.joint_set_ik_options(
@@ -128,14 +124,20 @@ func _update_motor_position_options() -> void:
 	
 	var joint_rid := get_rid()
 	if not joint_rid.is_valid():
+		push_error("Invalid joint rid")
 		return
-	
+
+	# workaround what seems like a rapier issue
+	# stiffness of 0.0 behaves strangely
+	# expected behaviour is for joint to hang freely
+	if is_zero_approx(motor_stiffness):
+		motor_stiffness = 0.00001	
 	RapierPhysicsServer3D.joint_set_motor_position_options(
 		joint_rid,
-		target_angle,
-		stiffness,
-		damping,
-		enable,
+		motor_target_angle,
+		motor_stiffness,
+		motor_damping,
+		motor_position_enabled,
 	)
 
 func _update_constrained_axes() -> void:

--- a/src/joints/rapier_revolute_joint.rs
+++ b/src/joints/rapier_revolute_joint.rs
@@ -25,10 +25,10 @@ pub struct RapierRevoluteJoint {
     angular_limit_enabled: bool,
     #[cfg(feature = "dim2")]
     softness: f32,
-    pub motor_target_position: f32,
-    pub motor_stiffness: f32,
-    pub motor_damping: f32,
-    pub motor_position_enabled: bool,
+    motor_target_position: f32,
+    motor_stiffness: f32,
+    motor_damping: f32,
+    motor_position_enabled: bool,
     base: RapierJointBase,
 }
 impl RapierRevoluteJoint {
@@ -227,11 +227,25 @@ impl RapierRevoluteJoint {
         );
     }
 
-    #[cfg(feature = "dim2")]
-    pub fn set_motor_options(&mut self, physics_engine: &mut PhysicsEngine) {
+    pub fn set_motor_position_options(
+        &mut self,
+        physics_engine: &mut PhysicsEngine,
+        motor_target_position: f32,
+        motor_stiffness: f32,
+        motor_damping: f32,
+        motor_position_enabled: bool,
+    ) {
         if !self.base.is_valid() {
             return;
         }
+        self.motor_target_position = motor_target_position;
+        self.motor_stiffness = motor_stiffness;
+        self.motor_damping = motor_damping;
+        self.motor_position_enabled = motor_position_enabled;
+        #[cfg(feature = "dim2")]
+        let softness = self.softness;
+        #[cfg(feature = "dim3")]
+        let softness: f32 = 1.0;
         physics_engine.joint_change_revolute_params(
             self.base.get_space_id(),
             self.base.get_handle(),
@@ -240,32 +254,11 @@ impl RapierRevoluteJoint {
             self.angular_limit_enabled,
             self.motor_target_velocity,
             self.motor_enabled,
-            self.softness,
-            self.motor_target_position,
-            self.motor_stiffness,
-            self.motor_damping,
-            self.motor_position_enabled,
-        );
-    }
-
-    #[cfg(feature = "dim3")]
-    pub fn set_motor_options(&mut self, physics_engine: &mut PhysicsEngine) {
-        if !self.base.is_valid() {
-            return;
-        }
-        physics_engine.joint_change_revolute_params(
-            self.base.get_space_id(),
-            self.base.get_handle(),
-            self.angular_limit_lower,
-            self.angular_limit_upper,
-            self.angular_limit_enabled,
-            self.motor_target_velocity,
-            self.motor_enabled,
-            1.0,
-            self.motor_target_position,
-            self.motor_stiffness,
-            self.motor_damping,
-            self.motor_position_enabled,
+            softness,
+            motor_target_position,
+            motor_stiffness,
+            motor_damping,
+            motor_position_enabled,
         );
     }
 

--- a/src/joints/rapier_revolute_joint.rs
+++ b/src/joints/rapier_revolute_joint.rs
@@ -25,6 +25,10 @@ pub struct RapierRevoluteJoint {
     angular_limit_enabled: bool,
     #[cfg(feature = "dim2")]
     softness: f32,
+    pub motor_target_position: f32,
+    pub motor_stiffness: f32,
+    pub motor_damping: f32,
+    pub motor_position_enabled: bool,
     base: RapierJointBase,
 }
 impl RapierRevoluteJoint {
@@ -48,6 +52,10 @@ impl RapierRevoluteJoint {
             angular_limit_enabled: false,
             #[cfg(feature = "dim2")]
             softness: 0.0,
+            motor_target_position: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_position_enabled: false,
             base: RapierJointBase::default(),
         };
         let body_a_rid = body_a.get_base().get_rid();
@@ -80,6 +88,10 @@ impl RapierRevoluteJoint {
             0.0,
             false,
             joint_type,
+            0.0,
+            0.0,
+            0.0,
+            false,
             true,
         );
         Self {
@@ -89,6 +101,10 @@ impl RapierRevoluteJoint {
             motor_enabled: false,
             angular_limit_enabled: false,
             softness: 0.0,
+            motor_target_position: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_position_enabled: false,
             base: RapierJointBase::new(id, rid, space_id, space_handle, handle, joint_type),
         }
     }
@@ -113,6 +129,10 @@ impl RapierRevoluteJoint {
             motor_target_velocity: 0.0,
             motor_enabled: false,
             angular_limit_enabled: false,
+            motor_target_position: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_position_enabled: false,
             base: RapierJointBase::default(),
         };
         let body_a_rid = body_a.get_base().get_rid();
@@ -146,6 +166,10 @@ impl RapierRevoluteJoint {
             0.0,
             false,
             joint_type,
+            0.0,
+            0.0,
+            0.0,
+            false,
             true,
         );
         Self {
@@ -154,6 +178,10 @@ impl RapierRevoluteJoint {
             motor_target_velocity: 0.0,
             motor_enabled: false,
             angular_limit_enabled: false,
+            motor_target_position: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_position_enabled: false,
             base: RapierJointBase::new(id, rid, space_id, space_handle, handle, joint_type),
         }
     }
@@ -192,6 +220,52 @@ impl RapierRevoluteJoint {
             self.motor_target_velocity,
             self.motor_enabled,
             self.softness,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
+        );
+    }
+
+    #[cfg(feature = "dim2")]
+    pub fn set_motor_options(&mut self, physics_engine: &mut PhysicsEngine) {
+        if !self.base.is_valid() {
+            return;
+        }
+        physics_engine.joint_change_revolute_params(
+            self.base.get_space_id(),
+            self.base.get_handle(),
+            self.angular_limit_lower,
+            self.angular_limit_upper,
+            self.angular_limit_enabled,
+            self.motor_target_velocity,
+            self.motor_enabled,
+            self.softness,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
+        );
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn set_motor_options(&mut self, physics_engine: &mut PhysicsEngine) {
+        if !self.base.is_valid() {
+            return;
+        }
+        physics_engine.joint_change_revolute_params(
+            self.base.get_space_id(),
+            self.base.get_handle(),
+            self.angular_limit_lower,
+            self.angular_limit_upper,
+            self.angular_limit_enabled,
+            self.motor_target_velocity,
+            self.motor_enabled,
+            1.0,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
         );
     }
 
@@ -226,6 +300,10 @@ impl RapierRevoluteJoint {
             self.motor_target_velocity,
             self.motor_enabled,
             1.0,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
         );
     }
 
@@ -278,6 +356,10 @@ impl RapierRevoluteJoint {
             self.motor_target_velocity,
             self.motor_enabled,
             self.softness,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
         );
     }
 
@@ -309,6 +391,10 @@ impl RapierRevoluteJoint {
             self.motor_target_velocity,
             self.motor_enabled,
             1.0,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
         );
     }
 

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -4,7 +4,7 @@ use rapier::prelude::*;
 use crate::joints::rapier_joint_base::RapierJointType;
 use crate::rapier_wrapper::prelude::*;
 impl PhysicsEngine {
-    #[cfg(feature = "dim2")]
+    // Using this in dim3 for motor position targeting for 3D #[cfg(feature = "dim2")]
     fn godot_spring_to_rapier_accel(stiffness: Real, damping: Real) -> (Real, Real) {
         // Godot stiffness is in N/m, convert to frequency: omega = sqrt(k/m)
         // For AccelerationBased, assume unit mass (m=1)
@@ -135,6 +135,10 @@ impl PhysicsEngine {
         motor_target_velocity: Real,
         motor_enabled: bool,
         joint_type: RapierJointType,
+        motor_target_position: Real,
+        motor_stiffness: Real,
+        motor_damping: Real,
+        motor_position_enabled: bool,
         disable_collision: bool,
     ) -> JointHandle {
         self.body_wake_up(world_handle, body_handle_1, false);
@@ -148,8 +152,18 @@ impl PhysicsEngine {
                 joint = joint.limits([angular_limit_lower, angular_limit_upper]);
             }
             if motor_enabled {
-                joint = joint.motor_velocity(motor_target_velocity, 0.0);
-                joint = joint.motor_model(MotorModel::AccelerationBased);
+                joint = joint
+                    .motor_velocity(motor_target_velocity, 0.0)
+                    .motor_max_force(Real::MAX)
+                    .motor_model(MotorModel::AccelerationBased);
+            }
+            if motor_position_enabled {
+                let (rapier_stiffness, rapier_damping) =
+                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
+                joint = joint
+                    .motor_position(motor_target_position, rapier_stiffness, rapier_damping)
+                    .motor_max_force(Real::MAX)
+                    .motor_model(MotorModel::AccelerationBased);
             }
             return physics_world.insert_joint(body_handle_1, body_handle_2, joint_type, joint);
         }
@@ -173,14 +187,19 @@ impl PhysicsEngine {
         motor_target_velocity: Real,
         motor_enabled: bool,
         joint_type: RapierJointType,
+        motor_target_position: Real,
+        motor_stiffness: Real,
+        motor_damping: Real,
+        motor_position_enabled: bool,
         disable_collision: bool,
     ) -> JointHandle {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
             // Extract the hinge axis (X-axis) from the rotation matrices
-            let axis1_vec = axis_1 * Vector::X;
-            let axis2_vec = axis_2 * Vector::X;
+            // Rapier hinge axis is X, but godot is Z
+            let axis1_vec = axis_1 * Vector::Z;
+            let axis2_vec = axis_2 * Vector::Z;
             // Use GenericJointBuilder to set both local axes
             let mut joint = GenericJointBuilder::new(JointAxesMask::LOCKED_REVOLUTE_AXES)
                 .local_anchor1(anchor_1)
@@ -193,6 +212,19 @@ impl PhysicsEngine {
             }
             if motor_enabled {
                 joint = joint.motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0);
+            }
+            if motor_position_enabled {
+                let (rapier_stiffness, rapier_damping) =
+                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
+                joint = joint
+                    .motor_position(
+                        JointAxis::AngX,
+                        motor_target_position,
+                        rapier_stiffness,
+                        rapier_damping,
+                    )
+                    .motor_max_force(JointAxis::AngX, Real::MAX)
+                    .motor_model(JointAxis::AngX, MotorModel::AccelerationBased);
             }
             return physics_world.insert_joint(
                 body_handle_1,
@@ -315,6 +347,10 @@ impl PhysicsEngine {
         motor_target_velocity: Real,
         motor_enabled: bool,
         softness: Real,
+        motor_target_position: Real,
+        motor_stiffness: Real,
+        motor_damping: Real,
+        motor_position_enabled: bool,
     ) {
         self.joint_wake_up_connected_rigidbodies(world_handle, joint_handle);
         if let Some(physics_world) = self.get_mut_world(world_handle)
@@ -330,6 +366,14 @@ impl PhysicsEngine {
             }
             if angular_limit_enabled {
                 joint.set_limits([angular_limit_lower, angular_limit_upper]);
+            }
+            if motor_position_enabled {
+                let (rapier_stiffness, rapier_damping) =
+                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
+                joint
+                    .set_motor_position(motor_target_position, rapier_stiffness, rapier_damping)
+                    .set_motor_max_force(Real::MAX)
+                    .set_motor_model(MotorModel::AccelerationBased);
             }
             if softness <= 0.0 {
                 joint.data.softness.natural_frequency = 1.0e6;

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -2,9 +2,11 @@ use godot::global::godot_error;
 use rapier::prelude::*;
 
 use crate::joints::rapier_joint_base::RapierJointType;
+#[cfg(feature = "dim3")]
+use crate::rapier_wrapper::joint::glamx::Quat;
 use crate::rapier_wrapper::prelude::*;
 impl PhysicsEngine {
-    // Using this in dim3 for motor position targeting for 3D #[cfg(feature = "dim2")]
+    #[cfg(feature = "dim2")]
     fn godot_spring_to_rapier_accel(stiffness: Real, damping: Real) -> (Real, Real) {
         // Godot stiffness is in N/m, convert to frequency: omega = sqrt(k/m)
         // For AccelerationBased, assume unit mass (m=1)
@@ -158,10 +160,8 @@ impl PhysicsEngine {
                     .motor_model(MotorModel::AccelerationBased);
             }
             if motor_position_enabled {
-                let (rapier_stiffness, rapier_damping) =
-                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
                 joint = joint
-                    .motor_position(motor_target_position, rapier_stiffness, rapier_damping)
+                    .motor_position(motor_target_position, motor_stiffness, motor_damping)
                     .motor_max_force(Real::MAX)
                     .motor_model(MotorModel::AccelerationBased);
             }
@@ -196,16 +196,18 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
-            // Extract the hinge axis (X-axis) from the rotation matrices
-            // Rapier hinge axis is X, but godot is Z
-            let axis1_vec = axis_1 * Vector::Z;
-            let axis2_vec = axis_2 * Vector::Z;
+            // Rapier revolute hinge axis is X, but godot is Z
+            // Transforming poses from z to x so that we can use the simplified Rapier
+            // revolute joint functions in other parts of code
+            // (rather than setting up a GenericJoint with AngZ free axis)
+            let z_to_x =
+                Quat::from_axis_angle(Vec3::new(0.0, 1.0, 0.0), std::f32::consts::FRAC_PI_2);
+            let pose_1 = Pose::from_parts(anchor_1, axis_1 * z_to_x);
+            let pose_2 = Pose::from_parts(anchor_2, axis_2 * z_to_x);
             // Use GenericJointBuilder to set both local axes
             let mut joint = GenericJointBuilder::new(JointAxesMask::LOCKED_REVOLUTE_AXES)
-                .local_anchor1(anchor_1)
-                .local_anchor2(anchor_2)
-                .local_axis1(axis1_vec)
-                .local_axis2(axis2_vec)
+                .local_frame1(pose_1)
+                .local_frame2(pose_2)
                 .contacts_enabled(!disable_collision);
             if angular_limit_enabled {
                 joint = joint.limits(JointAxis::AngX, [angular_limit_lower, angular_limit_upper]);
@@ -214,14 +216,12 @@ impl PhysicsEngine {
                 joint = joint.motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0);
             }
             if motor_position_enabled {
-                let (rapier_stiffness, rapier_damping) =
-                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
                 joint = joint
                     .motor_position(
                         JointAxis::AngX,
                         motor_target_position,
-                        rapier_stiffness,
-                        rapier_damping,
+                        motor_stiffness,
+                        motor_damping,
                     )
                     .motor_max_force(JointAxis::AngX, Real::MAX)
                     .motor_model(JointAxis::AngX, MotorModel::AccelerationBased);
@@ -368,10 +368,8 @@ impl PhysicsEngine {
                 joint.set_limits([angular_limit_lower, angular_limit_upper]);
             }
             if motor_position_enabled {
-                let (rapier_stiffness, rapier_damping) =
-                    Self::godot_spring_to_rapier_accel(motor_stiffness, motor_damping);
                 joint
-                    .set_motor_position(motor_target_position, rapier_stiffness, rapier_damping)
+                    .set_motor_position(motor_target_position, motor_stiffness, motor_damping)
                     .set_motor_max_force(Real::MAX)
                     .set_motor_model(MotorModel::AccelerationBased);
             }

--- a/src/servers/rapier_physics_server_extra.rs
+++ b/src/servers/rapier_physics_server_extra.rs
@@ -206,7 +206,6 @@ macro_rules! make_rapier_server_godot_impl {
             }
 
             #[func]
-            /// Set custom motor position options for a specific joint.
             pub fn joint_set_motor_position_options(
                 joint: Rid,
                 target_pos: real,
@@ -217,14 +216,14 @@ macro_rules! make_rapier_server_godot_impl {
                 let physics_data = physics_data();
                 if let Some(RapierJoint::RapierRevoluteJoint(revolute)) =
                     physics_data.joints.get_mut(&joint)
-                //                if let Some(RapierJoint::RapierRevoluteJoint(revolute)) =
-                //                   physics_data.joints.get_mut(&joint)
                 {
-                    revolute.motor_target_position = target_pos;
-                    revolute.motor_stiffness = stiffness;
-                    revolute.motor_damping = damping;
-                    revolute.motor_position_enabled = enabled;
-                    revolute.set_motor_options(&mut physics_data.physics_engine);
+                    revolute.set_motor_position_options(
+                        &mut physics_data.physics_engine,
+                        target_pos,
+                        stiffness,
+                        damping,
+                        enabled,
+                    )
                 }
             }
 

--- a/src/servers/rapier_physics_server_extra.rs
+++ b/src/servers/rapier_physics_server_extra.rs
@@ -29,6 +29,7 @@ macro_rules! make_rapier_server_godot_impl {
         use $crate::bodies::rapier_collision_object::IRapierCollisionObject;
         use $crate::fluids::rapier_fluid::RapierFluid;
         use $crate::joints::rapier_joint::IRapierJoint;
+        use $crate::joints::rapier_joint::RapierJoint;
         use $crate::joints::rapier_joint_base::RapierJointType;
         use $crate::servers::RapierPhysicsServer;
         use $crate::servers::rapier_physics_server_extra::RapierBodyParam;
@@ -201,6 +202,29 @@ macro_rules! make_rapier_server_godot_impl {
                 if let Some(joint_obj) = physics_data.joints.get_mut(&joint) {
                     use rapier::dynamics::InverseKinematicsOption;
                     joint_obj.get_mut_base().custom_ik_options = InverseKinematicsOption::default();
+                }
+            }
+
+            #[func]
+            /// Set custom motor position options for a specific joint.
+            pub fn joint_set_motor_position_options(
+                joint: Rid,
+                target_pos: real,
+                stiffness: real,
+                damping: real,
+                enabled: bool,
+            ) {
+                let physics_data = physics_data();
+                if let Some(RapierJoint::RapierRevoluteJoint(revolute)) =
+                    physics_data.joints.get_mut(&joint)
+                //                if let Some(RapierJoint::RapierRevoluteJoint(revolute)) =
+                //                   physics_data.joints.get_mut(&joint)
+                {
+                    revolute.motor_target_position = target_pos;
+                    revolute.motor_stiffness = stiffness;
+                    revolute.motor_damping = damping;
+                    revolute.motor_position_enabled = enabled;
+                    revolute.set_motor_options(&mut physics_data.physics_engine);
                 }
             }
 


### PR DESCRIPTION
This addition exposes the motor position targeting functionality within Rapier Lib by adding properties to RapierPinJoint2D and RapierHingeJoint3D. 

I ended up adding it all to RapierRevoluteJoint and ignoring the other joints. Happy to discuss why in Discord.

Also fixed the HingeJoint3D axis bug while I was in that file.

I do have sample code for using it to make a cantilevered beam but not sure that really has a good home in the repository. I also have a documentation page for godot-rapier-physics-docs which I can PR.

#Fixes 505