### PR TITLE
Fix Joint3D poses, 6DOF joint motor pos & limits

### DIFF
--- a/src/joints/rapier_generic_6dof_joint_3d.rs
+++ b/src/joints/rapier_generic_6dof_joint_3d.rs
@@ -168,6 +168,7 @@ impl RapierGeneric6DOFJoint3D {
                 axis_params.angular_spring_damping,
                 axis_params.angular_spring_stiffness,
                 axis_params.angular_spring_equilibrium_point,
+                axis_params.enable_angular_limit,
             );
         } else {
             physics_engine.joint_change_generic_6dof_axis_param(
@@ -183,6 +184,7 @@ impl RapierGeneric6DOFJoint3D {
                 axis_params.linear_spring_damping,
                 axis_params.linear_spring_stiffness,
                 axis_params.linear_spring_equilibrium_point,
+                axis_params.enable_linear_limit,
             );
         }
     }

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -279,15 +279,14 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
-            // Extract the X axis from the rotation matrices
-            let axis1_vec = axis_1 * Vector::X;
-            let axis2_vec = axis_2 * Vector::X;
+            let pose_1 = Pose::from_parts(anchor_1, axis_1);
+            let pose_2 = Pose::from_parts(anchor_2, axis_2);
             // Use GenericJointBuilder to set both local axes for prismatic joint
             let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_PRISMATIC_AXES)
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
-                .local_axis1(axis1_vec)
-                .local_axis2(axis2_vec)
+                .local_frame1(pose_1)
+                .local_frame2(pose_2)
                 .limits(JointAxis::LinX, [linear_limit_lower, linear_limit_upper])
                 .contacts_enabled(!disable_collision);
             return physics_world.insert_joint(
@@ -548,14 +547,13 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
             // Create a generic joint that allows all 6 degrees of freedom
-            // Extract the X axis from the rotation as UnitVector
-            let axis1_vec = axis_1 * Vector::X;
-            let axis2_vec = axis_2 * Vector::X;
+            let pose_1 = Pose::from_parts(anchor_1, axis_1);
+            let pose_2 = Pose::from_parts(anchor_2, axis_2);
             let joint = GenericJointBuilder::new(JointAxesMask::FREE_FIXED_AXES)
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
-                .local_axis1(axis1_vec)
-                .local_axis2(axis2_vec)
+                .local_frame1(pose_1)
+                .local_frame2(pose_2)
                 .contacts_enabled(!disable_collision);
             return physics_world.insert_joint(body_handle_1, body_handle_2, joint_type, joint);
         }
@@ -585,15 +583,14 @@ impl PhysicsEngine {
             // Use swing_span / sqrt(2) to get the per-axis limit
             let swing_limit = swing_span / 2.0f32.sqrt();
             let twist_limit = twist_span / 2.0;
-            // Extract the X axis from the rotation as UnitVector
-            let axis1_vec = axis_1 * Vector::X;
-            let axis2_vec = axis_2 * Vector::X;
+            let pose_1 = Pose::from_parts(anchor_1, axis_1);
+            let pose_2 = Pose::from_parts(anchor_2, axis_2);
             // Create a generic joint with locked translations and limited rotations
             let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
-                .local_axis1(axis1_vec)
-                .local_axis2(axis2_vec)
+                .local_frame1(pose_1)
+                .local_frame2(pose_2)
                 .limits(JointAxis::AngX, [-swing_limit, swing_limit])
                 .limits(JointAxis::AngY, [-swing_limit, swing_limit])
                 .limits(JointAxis::AngZ, [-twist_limit, twist_limit])
@@ -640,6 +637,7 @@ impl PhysicsEngine {
         spring_damping: Real,
         spring_stiffness: Real,
         spring_equilibrium_point: Real,
+        enable_limit: bool,
     ) {
         self.joint_wake_up_connected_rigidbodies(world_handle, joint_handle);
         if let Some(physics_world) = self.get_mut_world(world_handle)
@@ -650,7 +648,11 @@ impl PhysicsEngine {
                     "Both spring and motor model are enabled on joint, this is currently not implemented, motor will be given precidence!"
                 );
             }
-            joint.set_limits(axis, [lower_limit, limit_upper]);
+            if enable_limit {
+                joint.set_limits(axis, [lower_limit, limit_upper]);
+            } else {
+                joint.limit_axes.remove(JointAxesMask::from(axis));
+            }
             if enable_motor {
                 joint.set_motor_model(axis, MotorModel::ForceBased);
                 joint.set_motor_max_force(axis, motor_force_limit);
@@ -664,6 +666,7 @@ impl PhysicsEngine {
                     spring_stiffness,
                     spring_damping,
                 );
+                joint.set_motor_max_force(axis, Real::MAX);
             } else {
                 joint.set_motor_max_force(axis, 0.0);
                 joint.set_motor(axis, 0.0, 0.0, 0.0, 0.0);


### PR DESCRIPTION
Changed most 3D joints to use 2 full poses in the Generic Joint Builder, rather than two axes. This should fix orientation mismatches that were showing up in a lot of 3D joint issues. This has only been tested on the 6DOF joint using the sample from #468 as well as the 3D HingeJoint which was fixed in the same way in my last PR. 

Given that both HingeJoint3D and the 6DOF joint were having the same problem and the fix has been tested on those two, and joint setup with poses should be more robust than joint setup with X axes anyway, I figure that this is ready to pull without extensive testing. I don't think the joint constraints can be working fully without this.

Fixed some problems unique to 6DOF. Added ability to disable joint limits (which wasn't working) and set maximum force when setting motor position options (so that the spring that people set up actually does something).

- Fixes 468