### PR TITLE
Fix Issues with 3D Joints

### DIFF
--- a/bin3d/interactive_3d_joint_tests/compound_6dof_joint_3d_sample_2.tscn
+++ b/bin3d/interactive_3d_joint_tests/compound_6dof_joint_3d_sample_2.tscn
@@ -1,0 +1,105 @@
+[gd_scene format=3 uid="uid://cfgmbnapnnxl7"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_tivl1"]
+[ext_resource type="Script" uid="uid://m6wo3jh4qcir" path="res://addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd" id="2_auqaf"]
+[ext_resource type="Script" uid="uid://bbg8vb48w4j8r" path="res://addons/godot-rapier3d/custom_nodes/rapier_generic_6dof_joint_3d.gd" id="3_in2u4"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_t67pj"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_x5tgi"]
+
+[node name="Compound6dofJoint3DTest" type="Node3D" unique_id=1697557956]
+editor_description = "This scene demonstrates how to buid a functional ConeTwistJoint3D out of two joints and a dummy rigid body. This sample has less DOF per joint, so it avoids issues with compound angle limits"
+script = ExtResource("1_tivl1")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="Node3D" type="Node3D" parent="." unique_id=1909778838]
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="Node3D" unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 2.5, 0)
+gravity_scale = 0.0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="DummyRigidBody" type="RigidBody3D" parent="Node3D" unique_id=664594020]
+unique_name_in_owner = true
+editor_description = "The Dummy body cannot be zero or close to zero mass. Seems like equal mass should trasmit forces most efficiently."
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, 0)
+collision_layer = 0
+collision_mask = 0
+gravity_scale = 0.0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/DummyRigidBody" unique_id=244543052]
+shape = SubResource("SphereShape3D_t67pj")
+
+[node name="RapierHingeJoint3D" type="HingeJoint3D" parent="Node3D/DummyRigidBody" unique_id=259652772]
+transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 0, 0, 0)
+node_a = NodePath("..")
+node_b = NodePath("../../RigidBody3DBodyB")
+angular_limit/enable = true
+script = ExtResource("2_auqaf")
+metadata/_custom_type_script = "uid://m6wo3jh4qcir"
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="Node3D" unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+collision_layer = 0
+collision_mask = 0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierGeneric6DOFJoint3D" type="Generic6DOFJoint3D" parent="Node3D" unique_id=1708672673]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../DummyRigidBody")
+angular_limit_y/upper_angle = 0.7853982
+angular_limit_y/lower_angle = -0.7853982
+angular_limit_z/upper_angle = 0.7853982
+angular_limit_z/lower_angle = -0.7853982
+angular_motor_y/target_velocity = 0.17453292
+script = ExtResource("3_in2u4")
+metadata/_custom_type_script = "uid://bbg8vb48w4j8r"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RapierGeneric6DOFJoint3D" unique_id=1872606642]
+mesh = SubResource("SphereMesh_x5tgi")

--- a/bin3d/interactive_3d_joint_tests/cone_twist_joint_3d_test.tscn
+++ b/bin3d/interactive_3d_joint_tests/cone_twist_joint_3d_test.tscn
@@ -1,0 +1,79 @@
+[gd_scene format=3 uid="uid://l28g5v5jso14"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_brabs"]
+[ext_resource type="Script" uid="uid://bgep0e126vbjr" path="res://addons/godot-rapier3d/custom_nodes/rapier_cone_twist_joint_3d.gd" id="2_qx45g"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_x5tgi"]
+
+[node name="ConeTwistJoint3DTest" type="Node3D" unique_id=1697557956]
+script = ExtResource("1_brabs")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="Node3D" type="Node3D" parent="." unique_id=1909778838]
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="Node3D" unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 2.5, 0)
+collision_layer = 0
+collision_mask = 0
+gravity_scale = 0.0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="Node3D" unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+collision_layer = 0
+collision_mask = 0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierConeTwistJoint3D" type="ConeTwistJoint3D" parent="Node3D" unique_id=1640928763]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../RigidBody3DBodyB")
+twist_span = 1.5707964
+script = ExtResource("2_qx45g")
+metadata/_custom_type_script = "uid://bgep0e126vbjr"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RapierConeTwistJoint3D" unique_id=1872606642]
+mesh = SubResource("SphereMesh_x5tgi")

--- a/bin3d/interactive_3d_joint_tests/generic_6dof_joint_3d_test.tscn
+++ b/bin3d/interactive_3d_joint_tests/generic_6dof_joint_3d_test.tscn
@@ -1,0 +1,92 @@
+[gd_scene format=3 uid="uid://bsbrovphnhg4w"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_2dkvv"]
+[ext_resource type="Script" uid="uid://bbg8vb48w4j8r" path="res://addons/godot-rapier3d/custom_nodes/rapier_generic_6dof_joint_3d.gd" id="2_toskc"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_5vcnd"]
+
+[node name="Generic6DOFJoint3DTest" type="Node3D" unique_id=1697557956]
+script = ExtResource("1_2dkvv")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="." unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 2.263, 0)
+gravity_scale = 0.0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="." unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2634125, 0)
+collision_layer = 0
+collision_mask = 0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierGeneric6DOFJoint3D" type="Generic6DOFJoint3D" parent="." unique_id=1056924564]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2634125, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../RigidBody3DBodyB")
+linear_motor_x/target_velocity = 0.2
+linear_motor_x/force_limit = 300.0
+linear_motor_y/target_velocity = 0.2
+linear_motor_y/force_limit = 10000.0
+linear_motor_z/target_velocity = 0.2
+linear_motor_z/force_limit = 300.0
+angular_limit_x/upper_angle = 1.5707964
+angular_limit_x/lower_angle = -1.5707964
+angular_limit_y/upper_angle = 0.7853982
+angular_limit_y/lower_angle = -0.7853982
+angular_limit_z/upper_angle = 0.7853982
+angular_limit_z/lower_angle = -0.7853982
+angular_motor_y/enabled = true
+angular_motor_y/target_velocity = 0.17453292
+angular_motor_z/target_velocity = 0.17453292
+angular_spring_y/enabled = true
+angular_spring_y/stiffness = 1000.0
+angular_spring_y/damping = 10.0
+script = ExtResource("2_toskc")
+metadata/_custom_type_script = "uid://bbg8vb48w4j8r"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RapierGeneric6DOFJoint3D" unique_id=1872606642]
+mesh = SubResource("BoxMesh_5vcnd")

--- a/bin3d/interactive_3d_joint_tests/hinge_joint_3d_test.tscn
+++ b/bin3d/interactive_3d_joint_tests/hinge_joint_3d_test.tscn
@@ -1,0 +1,77 @@
+[gd_scene format=3 uid="uid://osg7dclw46a7"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_w5x60"]
+[ext_resource type="Script" uid="uid://m6wo3jh4qcir" path="res://addons/godot-rapier3d/custom_nodes/rapier_hinge_joint_3d.gd" id="2_v4ete"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_x5tgi"]
+
+[node name="HingeJoint3DTest" type="Node3D" unique_id=1697557956]
+script = ExtResource("1_w5x60")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="Node3D" type="Node3D" parent="." unique_id=1441342990]
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="Node3D" unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.2634125, 0)
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="Node3D" unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2634125, 0)
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierHingeJoint3D" type="HingeJoint3D" parent="Node3D" unique_id=1333530537]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2634125, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../RigidBody3DBodyB")
+motor/target_velocity = -0.17453292
+script = ExtResource("2_v4ete")
+motor_target_angle = 0.4799655442984406
+motor_stiffness = 10000.0
+motor_damping = 100.0
+metadata/_custom_type_script = "uid://m6wo3jh4qcir"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RapierHingeJoint3D" unique_id=1872606642]
+mesh = SubResource("SphereMesh_x5tgi")

--- a/bin3d/interactive_3d_joint_tests/joint_3d_test.gd
+++ b/bin3d/interactive_3d_joint_tests/joint_3d_test.gd
@@ -1,0 +1,34 @@
+extends Node3D
+
+@onready var static_body_a := %StaticBody3DBodyA as StaticBody3D
+@onready var rigid_body_b := %RigidBody3DBodyB as RigidBody3D
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(_delta: float) -> void:
+	var move_in_plane := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	var move := Vector3(move_in_plane.x, -move_in_plane.y, 0.0)
+
+	if Input.is_key_pressed(Key.KEY_L):
+		move.z = 1.0
+	elif Input.is_key_label_pressed(Key.KEY_K):
+		move.z = -1.0
+
+	rigid_body_b.apply_central_force(move * 4.0)
+
+	var torque := Vector3.ZERO
+	if Input.is_key_pressed(Key.KEY_W):
+		torque.x = 1.0
+	elif Input.is_key_label_pressed(Key.KEY_S):
+		torque.x = -1.0
+	if Input.is_key_pressed(Key.KEY_A):
+		torque.y = -1.0
+	elif Input.is_key_label_pressed(Key.KEY_D):
+		torque.y = 1.0
+	if Input.is_key_pressed(Key.KEY_Q):
+		torque.z = -1.0
+	elif Input.is_key_pressed(Key.KEY_E):
+		torque.z = 1.0
+	
+	# convert torque from local -> global
+	torque = rigid_body_b.global_transform.basis * torque
+	rigid_body_b.apply_torque(torque * 4.0)

--- a/bin3d/interactive_3d_joint_tests/joint_3d_test.gd.uid
+++ b/bin3d/interactive_3d_joint_tests/joint_3d_test.gd.uid
@@ -1,0 +1,1 @@
+uid://kejg1iln41uw

--- a/bin3d/interactive_3d_joint_tests/pin_joint_3d_test.tscn
+++ b/bin3d/interactive_3d_joint_tests/pin_joint_3d_test.tscn
@@ -1,0 +1,72 @@
+[gd_scene format=3 uid="uid://bvkpuacurqd5e"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_8c1dq"]
+[ext_resource type="Script" uid="uid://dhr1ct2k7gtb" path="res://addons/godot-rapier3d/custom_nodes/rapier_pin_joint_3d.gd" id="2_m44be"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_x5tgi"]
+
+[node name="PinJoint3DTest" type="Node3D" unique_id=1697557956]
+script = ExtResource("1_8c1dq")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="." unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.2634125, 0)
+gravity_scale = 0.0
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="." unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2634125, 0)
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierPinJoint3D" type="PinJoint3D" parent="." unique_id=972609561]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2634125, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../RigidBody3DBodyB")
+script = ExtResource("2_m44be")
+metadata/_custom_type_script = "uid://dhr1ct2k7gtb"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RapierPinJoint3D" unique_id=1872606642]
+mesh = SubResource("SphereMesh_x5tgi")

--- a/bin3d/interactive_3d_joint_tests/readme.txt
+++ b/bin3d/interactive_3d_joint_tests/readme.txt
@@ -1,0 +1,29 @@
+These joint tests are minimal scenes set up to
+make it quick and easy to toy around with 3D joints 
+and verify their behaviour between different engines. 
+
+They are here as a convenience for 
+contributors who may be working on the joints
+code. They could be deleted if they no 
+longer serve any value.
+
+There is a sample scene for every Godot Joint3D.
+
+The compound 6dof sample shows the use of 
+two joints compounded into one in order to 
+better match the limit behaviour of the Jolt
+6dof joint. The Jolt 6dof joint uses swing/twist
+axes with a pyramid constraint on the swing.
+Rapier can't currently match Jolt's particular
+setup with a single joint (as of 0.32.0). 
+
+Another way of matching Jolt 6dof limit behaviour
+would be to implement limits using external
+colliders to stop the rigid body where you
+want it limited.
+
+This behaviour difference, along with workarounds
+may be something worth documenting for users in
+the future. We could also include workaround 
+samples like the one here, if users actually hit
+up against these issues in practice.

--- a/bin3d/interactive_3d_joint_tests/slider_joint_3d_test.tscn
+++ b/bin3d/interactive_3d_joint_tests/slider_joint_3d_test.tscn
@@ -1,0 +1,74 @@
+[gd_scene format=3 uid="uid://ck4p1gn0yitgq"]
+
+[ext_resource type="Script" uid="uid://kejg1iln41uw" path="res://interactive_3d_joint_tests/joint_3d_test.gd" id="1_jfcjf"]
+[ext_resource type="Script" uid="uid://4incgaaw3wgq" path="res://addons/godot-rapier3d/custom_nodes/rapier_slider_joint_3d.gd" id="2_jlt0o"]
+
+[sub_resource type="WorldBoundaryShape3D" id="WorldBoundaryShape3D_n1ehq"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ny4cl"]
+size = Vector2(20, 20)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_u0bgm"]
+albedo_color = Color(0.27719998, 0.44, 0.29347998, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ldjty"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_xn13u"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n1ehq"]
+
+[sub_resource type="SphereMesh" id="SphereMesh_x5tgi"]
+
+[node name="SliderJoint3DTest" type="Node3D" unique_id=1697557956]
+script = ExtResource("1_jfcjf")
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=636902479]
+transform = Transform3D(0.9673253, 7.1260637e-09, 0.2535385, -0.041348297, 0.9866121, 0.15775615, -0.2501441, -0.1630849, 0.9543748, 1.8879976, 1.7878278, 3.2155585)
+
+[node name="StaticBody3DGround" type="StaticBody3D" parent="." unique_id=1589629082]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3DGround" unique_id=1906510716]
+shape = SubResource("WorldBoundaryShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=454066918]
+mesh = SubResource("PlaneMesh_ny4cl")
+surface_material_override/0 = SubResource("StandardMaterial3D_u0bgm")
+
+[node name="Node3D" type="Node3D" parent="." unique_id=182779408]
+
+[node name="RigidBody3DBodyB" type="RigidBody3D" parent="Node3D" unique_id=737201279]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.2634125, 0)
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/RigidBody3DBodyB" unique_id=1205331748]
+shape = SubResource("BoxShape3D_ldjty")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RigidBody3DBodyB" unique_id=1791650056]
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="StaticBody3DBodyA" type="StaticBody3D" parent="Node3D" unique_id=1427315890]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2634125, 0)
+metadata/_edit_group_ = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Node3D/StaticBody3DBodyA" unique_id=1865381364]
+visible = false
+shape = SubResource("BoxShape3D_n1ehq")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/StaticBody3DBodyA" unique_id=852476644]
+visible = false
+mesh = SubResource("BoxMesh_xn13u")
+
+[node name="RapierSliderJoint3D" type="SliderJoint3D" parent="Node3D" unique_id=2067206819]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2634125, 0)
+node_a = NodePath("../StaticBody3DBodyA")
+node_b = NodePath("../RigidBody3DBodyB")
+linear_limit/lower_distance = -2.0
+script = ExtResource("2_jlt0o")
+metadata/_custom_type_script = "uid://4incgaaw3wgq"
+metadata/_edit_group_ = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Node3D/RapierSliderJoint3D" unique_id=1872606642]
+mesh = SubResource("SphereMesh_x5tgi")

--- a/src/joints/rapier_generic_6dof_joint_3d.rs
+++ b/src/joints/rapier_generic_6dof_joint_3d.rs
@@ -155,19 +155,22 @@ impl RapierGeneric6DOFJoint3D {
             return;
         }
         if is_angular {
+            // angles are being inverted to make rapier behavoiur match Jolt
+            // A quick look at the Jolt source code, and it is also inverting angles,
+            // presumably to match a peculiarity of Godot Physics.
             physics_engine.joint_change_generic_6dof_axis_param(
                 self.base.get_space_id(),
                 self.base.get_handle(),
                 rapier_axis,
-                axis_params.angular_lower_limit,
-                axis_params.angular_upper_limit,
+                -axis_params.angular_upper_limit,
+                -axis_params.angular_lower_limit,
                 axis_params.enable_angular_motor,
-                axis_params.angular_motor_target_velocity,
+                -axis_params.angular_motor_target_velocity,
                 axis_params.angular_motor_force_limit,
                 axis_params.enable_angular_spring,
                 axis_params.angular_spring_damping,
                 axis_params.angular_spring_stiffness,
-                axis_params.angular_spring_equilibrium_point,
+                -axis_params.angular_spring_equilibrium_point,
                 axis_params.enable_angular_limit,
             );
         } else {

--- a/src/joints/rapier_revolute_joint.rs
+++ b/src/joints/rapier_revolute_joint.rs
@@ -29,6 +29,8 @@ pub struct RapierRevoluteJoint {
     motor_stiffness: f32,
     motor_damping: f32,
     motor_position_enabled: bool,
+    #[cfg(feature = "dim3")]
+    motor_max_force: f32,
     base: RapierJointBase,
 }
 impl RapierRevoluteJoint {
@@ -133,6 +135,7 @@ impl RapierRevoluteJoint {
             motor_stiffness: 0.0,
             motor_damping: 0.0,
             motor_position_enabled: false,
+            motor_max_force: 0.0,
             base: RapierJointBase::default(),
         };
         let body_a_rid = body_a.get_base().get_rid();
@@ -170,6 +173,7 @@ impl RapierRevoluteJoint {
             0.0,
             0.0,
             false,
+            0.0,
             true,
         );
         Self {
@@ -182,6 +186,7 @@ impl RapierRevoluteJoint {
             motor_stiffness: 0.0,
             motor_damping: 0.0,
             motor_position_enabled: false,
+            motor_max_force: 0.0,
             base: RapierJointBase::new(id, rid, space_id, space_handle, handle, joint_type),
         }
     }
@@ -259,6 +264,8 @@ impl RapierRevoluteJoint {
             motor_stiffness,
             motor_damping,
             motor_position_enabled,
+            #[cfg(feature = "dim3")]
+            self.motor_max_force,
         );
     }
 
@@ -279,6 +286,9 @@ impl RapierRevoluteJoint {
             physics_server_3d::HingeJointParam::MOTOR_TARGET_VELOCITY => {
                 self.motor_target_velocity = p_value;
             }
+            physics_server_3d::HingeJointParam::MOTOR_MAX_IMPULSE => {
+                self.motor_max_force = p_value / Self::estimate_physics_step();
+            }
             _ => {}
         }
         if !self.base.is_valid() {
@@ -297,6 +307,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
+            self.motor_max_force,
         );
     }
 
@@ -311,12 +322,33 @@ impl RapierRevoluteJoint {
         }
     }
 
+    // This function is used to convert MOTOR_MAX_IMPULSE into a force which
+    // can be passed onto rapier.
+    #[cfg(feature = "dim3")]
+    pub fn estimate_physics_step() -> f32 {
+        /*
+        // Use this method if we want to match Jolt's approach
+        // as of Godot 4.6.2 (However this approach perpetuates step variant behaviour)
+        let mut engine = <godot::classes::Engine as godot::obj::Singleton>::singleton();
+        let step = 1.0 / engine.get_physics_ticks_per_second() as f64;
+        let step_scaled = step * engine.get_time_scale();
+        step_scaled as f32
+        */
+        // Use this method if we want consistent behaviour
+        // during time scaling or changing of physics rate
+        // when physics step is 60.0 (default) behaviour will match Jolt
+        1.0 / 60.0
+    }
+
     #[cfg(feature = "dim3")]
     pub fn get_param(&self, p_param: physics_server_3d::HingeJointParam) -> f32 {
         match p_param {
             physics_server_3d::HingeJointParam::LIMIT_UPPER => self.angular_limit_upper,
             physics_server_3d::HingeJointParam::LIMIT_LOWER => self.angular_limit_lower,
             physics_server_3d::HingeJointParam::MOTOR_TARGET_VELOCITY => self.motor_target_velocity,
+            physics_server_3d::HingeJointParam::MOTOR_MAX_IMPULSE => {
+                self.motor_max_force * Self::estimate_physics_step()
+            }
             _ => 0.0,
         }
     }
@@ -388,6 +420,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
+            self.motor_max_force,
         );
     }
 

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -149,21 +149,16 @@ impl PhysicsEngine {
             let mut joint = RevoluteJointBuilder::new()
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
-                .contacts_enabled(!disable_collision);
+                .contacts_enabled(!disable_collision)
+                .motor_max_force(Real::MAX)
+                .motor_model(MotorModel::ForceBased);
             if angular_limit_enabled {
                 joint = joint.limits([angular_limit_lower, angular_limit_upper]);
             }
             if motor_enabled {
-                joint = joint
-                    .motor_velocity(motor_target_velocity, 0.0)
-                    .motor_max_force(Real::MAX)
-                    .motor_model(MotorModel::AccelerationBased);
-            }
-            if motor_position_enabled {
-                joint = joint
-                    .motor_position(motor_target_position, motor_stiffness, motor_damping)
-                    .motor_max_force(Real::MAX)
-                    .motor_model(MotorModel::AccelerationBased);
+                joint = joint.motor_velocity(motor_target_velocity, 0.0)
+            } else if motor_position_enabled {
+                joint = joint.motor_position(motor_target_position, motor_stiffness, motor_damping)
             }
             return physics_world.insert_joint(body_handle_1, body_handle_2, joint_type, joint);
         }
@@ -191,6 +186,7 @@ impl PhysicsEngine {
         motor_stiffness: Real,
         motor_damping: Real,
         motor_position_enabled: bool,
+        motor_max_force: Real,
         disable_collision: bool,
     ) -> JointHandle {
         self.body_wake_up(world_handle, body_handle_1, false);
@@ -213,9 +209,13 @@ impl PhysicsEngine {
                 joint = joint.limits(JointAxis::AngX, [angular_limit_lower, angular_limit_upper]);
             }
             if motor_enabled {
-                joint = joint.motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0);
-            }
-            if motor_position_enabled {
+                joint = joint
+                    // factor is just passed on verbatim as damping in RapierLib GenericJoint.set_motor()
+                    // 0.0 works as expected. Other settings can behave strangely.
+                    .motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0)
+                    .motor_model(JointAxis::AngX, MotorModel::AccelerationBased)
+                    .motor_max_force(JointAxis::AngX, motor_max_force);
+            } else if motor_position_enabled {
                 joint = joint
                     .motor_position(
                         JointAxis::AngX,
@@ -283,8 +283,6 @@ impl PhysicsEngine {
             let pose_2 = Pose::from_parts(anchor_2, axis_2);
             // Use GenericJointBuilder to set both local axes for prismatic joint
             let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_PRISMATIC_AXES)
-                .local_anchor1(anchor_1)
-                .local_anchor2(anchor_2)
                 .local_frame1(pose_1)
                 .local_frame2(pose_2)
                 .limits(JointAxis::LinX, [linear_limit_lower, linear_limit_upper])
@@ -350,27 +348,33 @@ impl PhysicsEngine {
         motor_stiffness: Real,
         motor_damping: Real,
         motor_position_enabled: bool,
+        #[cfg(feature = "dim3")] motor_max_force: Real,
     ) {
         self.joint_wake_up_connected_rigidbodies(world_handle, joint_handle);
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
             && let Some(joint) = joint.as_revolute_mut()
         {
-            if motor_enabled {
-                joint
-                    .set_motor_velocity(motor_target_velocity, 0.0)
-                    .set_motor_max_force(Real::MAX);
-            } else {
-                joint.set_motor_velocity(0.0, 0.0).set_motor_max_force(0.0);
-            }
+            // AccelerationBased is chosen for 2D joints to keep
+            // the numbers far smaller and provide invariant behaviour
+            // regardless of mass changes.
+            joint.set_motor_model(MotorModel::AccelerationBased);
+            joint.set_motor_max_force(Real::MAX);
             if angular_limit_enabled {
                 joint.set_limits([angular_limit_lower, angular_limit_upper]);
+            } else {
+                // As far as I can see, there is no function to turn off limits
+                // but we can mask them off in the base generic joint bit flags
+                joint.data.limit_axes.remove(JointAxesMask::ANG_X);
             }
-            if motor_position_enabled {
-                joint
-                    .set_motor_position(motor_target_position, motor_stiffness, motor_damping)
-                    .set_motor_max_force(Real::MAX)
-                    .set_motor_model(MotorModel::AccelerationBased);
+            if motor_enabled {
+                joint.set_motor(0.0, motor_target_velocity, 0.0, 0.0);
+                #[cfg(feature = "dim3")]
+                joint.set_motor_max_force(motor_max_force);
+            } else if motor_position_enabled {
+                joint.set_motor(motor_target_position, 0.0, motor_stiffness, motor_damping);
+            } else {
+                joint.data.motor_axes.remove(JointAxesMask::ANG_X);
             }
             if softness <= 0.0 {
                 joint.data.softness.natural_frequency = 1.0e6;
@@ -546,12 +550,24 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
-            // Create a generic joint that allows all 6 degrees of freedom
+            // NOTE: 6DOF Angle limits may not behave as expected or be
+            // unstable when there is more than one angular DOF.
+            //
+            // Jolt seems to use a swing twist constraint for it's 6DOF which
+            // improves the situation by eliminating path dependence problems.
+            // If Rapier could add a pyramid like constraint to it's coupled angular
+            // axes then we could match what Jolt is doing.
+            // As of Rapier 0.32.0, I don't believe we can match jolt's limit behavior.
+            //
+            // For now, if a user needs high angular DOF's with limits, they
+            // can construct a compound joint out of multiple low DOF joints
+            // with dummy rigid bodies between them.
+            //
+            // They could also use hidden colliders as a constraint, instead of joint limits
+            //
             let pose_1 = Pose::from_parts(anchor_1, axis_1);
             let pose_2 = Pose::from_parts(anchor_2, axis_2);
             let joint = GenericJointBuilder::new(JointAxesMask::FREE_FIXED_AXES)
-                .local_anchor1(anchor_1)
-                .local_anchor2(anchor_2)
                 .local_frame1(pose_1)
                 .local_frame2(pose_2)
                 .contacts_enabled(!disable_collision);
@@ -579,21 +595,24 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
-            // Approximate cone: limit swing on X and Y to create a "box" that fits inside the cone
-            // Use swing_span / sqrt(2) to get the per-axis limit
-            let swing_limit = swing_span / 2.0f32.sqrt();
-            let twist_limit = twist_span / 2.0;
+            // A common use for this joint seems to be a shoulder for rag dolls.
+            // The arm held out to a middle position might represent the x axis (twist)
+            // The y and z rotation limits offer a kind of cone around that axis
+            // for the arm to move in (swing)
+            //
+            // Rapier's coupled_axes feature makes the whole joint work as intended
+            //
+            // Note that Godot Docs and the widget that Godot draws (as of 4.6.2)
+            // do not match what Jolt and the default engine are doing.
             let pose_1 = Pose::from_parts(anchor_1, axis_1);
             let pose_2 = Pose::from_parts(anchor_2, axis_2);
-            // Create a generic joint with locked translations and limited rotations
             let joint = GenericJointBuilder::new(JointAxesMask::LOCKED_SPHERICAL_AXES)
-                .local_anchor1(anchor_1)
-                .local_anchor2(anchor_2)
                 .local_frame1(pose_1)
                 .local_frame2(pose_2)
-                .limits(JointAxis::AngX, [-swing_limit, swing_limit])
-                .limits(JointAxis::AngY, [-swing_limit, swing_limit])
-                .limits(JointAxis::AngZ, [-twist_limit, twist_limit])
+                .coupled_axes(JointAxesMask::ANG_Y | JointAxesMask::ANG_Z)
+                .limits(JointAxis::AngX, [-twist_span, twist_span])
+                .limits(JointAxis::AngY, [-swing_span, swing_span])
+                .limits(JointAxis::AngZ, [-swing_span, swing_span])
                 .contacts_enabled(!disable_collision);
             return physics_world.insert_joint(body_handle_1, body_handle_2, joint_type, joint);
         }
@@ -612,15 +631,12 @@ impl PhysicsEngine {
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
         {
-            let swing_limit = swing_span / 2.0f32.sqrt();
-            let twist_limit = twist_span / 2.0;
-            joint.set_limits(JointAxis::AngX, [-swing_limit, swing_limit]);
-            joint.set_limits(JointAxis::AngY, [-swing_limit, swing_limit]);
-            joint.set_limits(JointAxis::AngZ, [-twist_limit, twist_limit]);
+            joint.set_limits(JointAxis::AngX, [-twist_span, twist_span]);
+            joint.set_limits(JointAxis::AngY, [-swing_span, swing_span]);
+            joint.set_limits(JointAxis::AngZ, [-swing_span, swing_span]);
         }
     }
 
-    //TODO: Remove motor_enabled and spring_enabled once we have guidance on how to implement this properly
     #[cfg(feature = "dim3")]
     #[allow(clippy::too_many_arguments)]
     pub fn joint_change_generic_6dof_axis_param(
@@ -643,11 +659,8 @@ impl PhysicsEngine {
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
         {
-            if enable_motor && enable_spring {
-                godot::global::godot_warn!(
-                    "Both spring and motor model are enabled on joint, this is currently not implemented, motor will be given precidence!"
-                );
-            }
+            // motor velocity should override motor position settings to match
+            // how Jolt behaves.
             if enable_limit {
                 joint.set_limits(axis, [lower_limit, limit_upper]);
             } else {
@@ -656,20 +669,19 @@ impl PhysicsEngine {
             if enable_motor {
                 joint.set_motor_model(axis, MotorModel::ForceBased);
                 joint.set_motor_max_force(axis, motor_force_limit);
-                //TODO: where do we want to get the damping factor from: Higher in this case means the target velocity is approched more aggresively
-                joint.set_motor_velocity(axis, motor_target_velocity, 10.0);
+                joint.set_motor(axis, 0.0, motor_target_velocity, 0.0, 0.0);
             } else if enable_spring {
                 joint.set_motor_model(axis, MotorModel::AccelerationBased);
-                joint.set_motor_position(
+                joint.set_motor(
                     axis,
                     spring_equilibrium_point,
+                    0.0,
                     spring_stiffness,
                     spring_damping,
                 );
                 joint.set_motor_max_force(axis, Real::MAX);
             } else {
-                joint.set_motor_max_force(axis, 0.0);
-                joint.set_motor(axis, 0.0, 0.0, 0.0, 0.0);
+                joint.motor_axes.remove(JointAxesMask::from(axis));
             }
         }
     }

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -210,8 +210,6 @@ impl PhysicsEngine {
             }
             if motor_enabled {
                 joint = joint
-                    // factor is just passed on verbatim as damping in RapierLib GenericJoint.set_motor()
-                    // 0.0 works as expected. Other settings can behave strangely.
                     .motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0)
                     .motor_model(JointAxis::AngX, MotorModel::AccelerationBased)
                     .motor_max_force(JointAxis::AngX, motor_max_force);
@@ -355,16 +353,11 @@ impl PhysicsEngine {
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
             && let Some(joint) = joint.as_revolute_mut()
         {
-            // AccelerationBased is chosen for 2D joints to keep
-            // the numbers far smaller and provide invariant behaviour
-            // regardless of mass changes.
             joint.set_motor_model(MotorModel::AccelerationBased);
             joint.set_motor_max_force(Real::MAX);
             if angular_limit_enabled {
                 joint.set_limits([angular_limit_lower, angular_limit_upper]);
             } else {
-                // As far as I can see, there is no function to turn off limits
-                // but we can mask them off in the base generic joint bit flags
                 joint.data.limit_axes.remove(JointAxesMask::ANG_X);
             }
             if motor_enabled {


### PR DESCRIPTION
## Summary

Fix issues with 3D Joints

- Invert Generic6DOFJoint3D angle properties to match Godot peculiarity
- Add motor_max_impulse property support to HingeJoint3D
- Ensure motor velocity overrides motor position to match Jolt/Godot
- Ensure parameters such as limits can be both set or cleared by user at runtime
- Get rid of motor position and velocity warning
- Fix ConeTwistJoint3D using Rapier coupled_axes
- Add 3D Joint samples to bin3d for contributor testing

## Limitations

- One upstream feature limitation affecting angular limits in high DOF scenarios with Generic6dofJoint3D (documented in the code along with workaround suggestions).
- I haven’t fully tested Multibody joints. They seem to work with gravity but do not respond to applied forces and may crash / stall.

- Fixes #459
- Fixes #461 (fixed in earlier PR)

Addresses #460 (Impulse mode works, Multibody untested)
Addresses #463  (Impulse mode works, problems with test scene, Multibody untested)