### PR TITLE
Fix 2D cross platform determinism

### DIFF
--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -169,8 +169,8 @@ pub enum AreaUpdateMode {
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
 #[derive(Debug)]
 pub struct AreaExport<'a> {
-    pub(crate) area_state: &'a RapierAreaState,
-    pub(crate) base_state: &'a RapierCollisionObjectBaseState,
+    area_state: &'a RapierAreaState,
+    base_state: &'a RapierCollisionObjectBaseState,
 }
 impl ExportToImport for AreaExport<'_> {
     type Import = AreaImport;

--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -19,6 +19,7 @@ use servers::rapier_physics_singleton::PhysicsShapes;
 use servers::rapier_physics_singleton::PhysicsSpaces;
 use servers::rapier_physics_singleton::RapierId;
 use servers::rapier_physics_singleton::get_id_rid;
+use servers::rapier_physics_singleton::physics_data;
 
 use super::exportable_object::ExportToImport;
 use super::exportable_object::ExportableObject;
@@ -787,17 +788,27 @@ impl RapierArea {
         area_monitor_callback: Option<Callable>,
         physics_ids: &PhysicsIds,
     ) {
+        let physics_data = physics_data();
         for monitor_report in unhandled_events.values() {
             if monitor_report.state == 0 {
                 godot_error!("Invalid monitor state");
                 continue;
             }
             let rid = get_id_rid(monitor_report.id, physics_ids);
+            // Resolve the RapierId stored in instance_id to the real Godot instance_id
+            let godot_instance_id: i64 = if let Some(obj_rid) =
+                physics_data.ids.get(&monitor_report.instance_id)
+                && let Some(obj) = physics_data.collision_objects.get(obj_rid)
+            {
+                obj.get_base().get_instance_id() as i64
+            } else {
+                0
+            };
             let arg_array = if monitor_report.state > 0 {
                 vec![
                     AreaBodyStatus::ADDED.to_variant(),
                     rid.to_variant(),
-                    (monitor_report.instance_id as i64).to_variant(),
+                    godot_instance_id.to_variant(),
                     monitor_report.object_shape_index.to_variant(),
                     monitor_report.this_area_shape_index.to_variant(),
                 ]
@@ -805,7 +816,7 @@ impl RapierArea {
                 vec![
                     AreaBodyStatus::REMOVED.to_variant(),
                     rid.to_variant(),
-                    (monitor_report.instance_id as i64).to_variant(),
+                    godot_instance_id.to_variant(),
                     monitor_report.object_shape_index.to_variant(),
                     monitor_report.this_area_shape_index.to_variant(),
                 ]

--- a/src/bodies/rapier_area.rs
+++ b/src/bodies/rapier_area.rs
@@ -168,8 +168,8 @@ pub enum AreaUpdateMode {
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
 #[derive(Debug)]
 pub struct AreaExport<'a> {
-    area_state: &'a RapierAreaState,
-    base_state: &'a RapierCollisionObjectBaseState,
+    pub(crate) area_state: &'a RapierAreaState,
+    pub(crate) base_state: &'a RapierCollisionObjectBaseState,
 }
 impl ExportToImport for AreaExport<'_> {
     type Import = AreaImport;

--- a/src/bodies/rapier_direct_body_state_impl.rs
+++ b/src/bodies/rapier_direct_body_state_impl.rs
@@ -481,13 +481,11 @@ impl RapierDirectBodyStateImpl {
             && let Some(body) = body.get_body()
             && let Some(contact) = body.contacts().get(contact_idx as usize)
         {
-            // collider_instance_id now stores the RapierId for determinism.
-            // Look up the real Godot instance_id from the physics ID map.
             let rapier_id = contact.collider_instance_id;
-            if let Some(rid) = physics_data.ids.get(&rapier_id) {
-                if let Some(collider_obj) = physics_data.collision_objects.get(rid) {
-                    return collider_obj.get_base().get_instance_id();
-                }
+            if let Some(rid) = physics_data.ids.get(&rapier_id)
+                && let Some(collider_obj) = physics_data.collision_objects.get(rid)
+            {
+                return collider_obj.get_base().get_instance_id();
             }
         }
         0
@@ -499,16 +497,14 @@ impl RapierDirectBodyStateImpl {
             && let Some(body) = body.get_body()
             && let Some(contact) = body.contacts().get(contact_idx as usize)
         {
-            // collider_instance_id now stores the RapierId for determinism.
-            // Look up the real Godot instance_id from the physics ID map.
             let rapier_id = contact.collider_instance_id;
-            if let Some(rid) = physics_data.ids.get(&rapier_id) {
-                if let Some(collider_obj) = physics_data.collision_objects.get(rid) {
-                    let instance_id = collider_obj.get_base().get_instance_id();
-                    match Gd::try_from_instance_id(InstanceId::from_i64(instance_id as i64)) {
-                        Ok(object) => return Some(object),
-                        Err(_) => return None,
-                    }
+            if let Some(rid) = physics_data.ids.get(&rapier_id)
+                && let Some(collider_obj) = physics_data.collision_objects.get(rid)
+            {
+                let instance_id = collider_obj.get_base().get_instance_id();
+                match Gd::try_from_instance_id(InstanceId::from_i64(instance_id as i64)) {
+                    Ok(object) => return Some(object),
+                    Err(_) => return None,
                 }
             }
         }

--- a/src/bodies/rapier_direct_body_state_impl.rs
+++ b/src/bodies/rapier_direct_body_state_impl.rs
@@ -481,7 +481,14 @@ impl RapierDirectBodyStateImpl {
             && let Some(body) = body.get_body()
             && let Some(contact) = body.contacts().get(contact_idx as usize)
         {
-            return contact.collider_instance_id;
+            // collider_instance_id now stores the RapierId for determinism.
+            // Look up the real Godot instance_id from the physics ID map.
+            let rapier_id = contact.collider_instance_id;
+            if let Some(rid) = physics_data.ids.get(&rapier_id) {
+                if let Some(collider_obj) = physics_data.collision_objects.get(rid) {
+                    return collider_obj.get_base().get_instance_id();
+                }
+            }
         }
         0
     }
@@ -492,11 +499,17 @@ impl RapierDirectBodyStateImpl {
             && let Some(body) = body.get_body()
             && let Some(contact) = body.contacts().get(contact_idx as usize)
         {
-            match Gd::try_from_instance_id(InstanceId::from_i64(
-                contact.collider_instance_id as i64,
-            )) {
-                Ok(object) => return Some(object),
-                Err(_) => return None,
+            // collider_instance_id now stores the RapierId for determinism.
+            // Look up the real Godot instance_id from the physics ID map.
+            let rapier_id = contact.collider_instance_id;
+            if let Some(rid) = physics_data.ids.get(&rapier_id) {
+                if let Some(collider_obj) = physics_data.collision_objects.get(rid) {
+                    let instance_id = collider_obj.get_base().get_instance_id();
+                    match Gd::try_from_instance_id(InstanceId::from_i64(instance_id as i64)) {
+                        Ok(object) => return Some(object),
+                        Err(_) => return None,
+                    }
+                }
             }
         }
         None

--- a/src/nodes/state_manager.rs
+++ b/src/nodes/state_manager.rs
@@ -8,7 +8,6 @@ use godot::classes::Marshalls;
 use godot::prelude::*;
 use hashbrown::HashMap;
 use hashbrown::HashSet;
-use rapier::geometry::ColliderHandle;
 use rapier::geometry::ColliderPair;
 
 use crate::bodies::exportable_object::ExportToImport;
@@ -16,13 +15,9 @@ use crate::bodies::exportable_object::ExportableObject;
 use crate::bodies::exportable_object::ImportToExport;
 use crate::bodies::exportable_object::ObjectExportState;
 use crate::bodies::exportable_object::ObjectImportState;
-use crate::bodies::rapier_area::AreaExport;
-use crate::bodies::rapier_body::BodyExport;
 use crate::bodies::rapier_collision_object::IRapierCollisionObject;
 use crate::bodies::rapier_collision_object::RapierCollisionObject;
-use crate::bodies::rapier_collision_object_base::RapierCollisionObjectBaseState;
 use crate::servers::RapierPhysicsServer;
-use crate::servers::rapier_physics_singleton::RapierId;
 use crate::servers::rapier_physics_singleton::physics_data;
 use crate::spaces::rapier_space::SpaceExport;
 use crate::spaces::rapier_space::SpaceImport;
@@ -75,75 +70,6 @@ impl CollatedObjectImportState {
             state: self.state.as_export(),
             shape_owners: export_state_map,
         }
-    }
-}
-/// A stripped-down version of the physics state that only contains deterministic data.
-/// Used for cross-instance state comparison (rollback mismatch detection).
-/// Excludes: physics_server_id, instance_ids, collider_instance_ids.
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-struct DeterministicExportState<'a> {
-    rapier_space: &'a SpaceExport<'a>,
-    physics_objects_state: BTreeMap<&'a String, DeterministicObjectState<'a>>,
-}
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-struct DeterministicObjectState<'a> {
-    state: DeterministicNodeState<'a>,
-    shape_owners: &'a BTreeMap<String, Vec<ObjectExportState<'a>>>,
-}
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-enum DeterministicNodeState<'a> {
-    Body(&'a BodyExport<'a>),
-    Area(DeterministicAreaState<'a>),
-    Other(&'a ObjectExportState<'a>),
-}
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-struct DeterministicAreaState<'a> {
-    base_state: &'a RapierCollisionObjectBaseState,
-    // Serialize monitored_objects keys and physics-relevant fields only
-    monitored_collider_pairs: Vec<(&'a (ColliderHandle, ColliderHandle), &'a RapierId, i32)>,
-}
-impl<'a> DeterministicExportState<'a> {
-    fn from_raw(raw: &'a RawExportState<'a>) -> Self {
-        let mut objects = BTreeMap::new();
-        for (path, collated) in &raw.physics_objects_state {
-            let det_state = match &collated.state {
-                ObjectExportState::Body(body) => DeterministicNodeState::Body(body),
-                ObjectExportState::Area(area) => DeterministicAreaState::from_area(area),
-                other => DeterministicNodeState::Other(other),
-            };
-            objects.insert(
-                path,
-                DeterministicObjectState {
-                    state: det_state,
-                    shape_owners: &collated.shape_owners,
-                },
-            );
-        }
-        DeterministicExportState {
-            rapier_space: &raw.rapier_space,
-            physics_objects_state: objects,
-        }
-    }
-}
-impl<'a> DeterministicAreaState<'a> {
-    fn from_area(area: &'a AreaExport<'a>) -> DeterministicNodeState<'a> {
-        let mut pairs: Vec<_> = area
-            .area_state
-            .monitored_objects
-            .iter()
-            .map(|(key, info)| (key, &info.other_collider_id, info.num_contacts))
-            .collect();
-        // Sort for deterministic output (HashMap iteration order is non-deterministic)
-        pairs.sort_by(|a, b| {
-            a.0.0
-                .into_raw_parts()
-                .cmp(&b.0.0.into_raw_parts())
-                .then(a.0.1.into_raw_parts().cmp(&b.0.1.into_raw_parts()))
-        });
-        DeterministicNodeState::Area(DeterministicAreaState {
-            base_state: area.base_state,
-            monitored_collider_pairs: pairs,
-        })
     }
 }
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
@@ -351,27 +277,6 @@ impl StateManager {
             self.serialize_state(raw_state, &format)
         } else {
             Variant::nil()
-        }
-    }
-
-    #[func]
-    /// Exports a deterministic representation of the physics state suitable for cross-instance
-    /// comparison (e.g. rollback netcode mismatch detection). This excludes process-specific
-    /// fields like instance IDs and the physics server counter that differ between Godot instances
-    /// even when the physics simulation is identical.
-    /// The output should NOT be used with import_state — use export_state for save/load.
-    fn export_deterministic_state(&mut self, in_space: Rid) -> PackedByteArray {
-        if let Some(raw_state) = self.fetch_state(in_space) {
-            let deterministic_state = DeterministicExportState::from_raw(&raw_state);
-            match bincode::serialize(&deterministic_state) {
-                Ok(b) => bin_to_packed_byte_array(b),
-                Err(err) => {
-                    godot_error!("Failed to serialize deterministic physics state: {}", err);
-                    PackedByteArray::new()
-                }
-            }
-        } else {
-            PackedByteArray::new()
         }
     }
 

--- a/src/nodes/state_manager.rs
+++ b/src/nodes/state_manager.rs
@@ -8,6 +8,7 @@ use godot::classes::Marshalls;
 use godot::prelude::*;
 use hashbrown::HashMap;
 use hashbrown::HashSet;
+use rapier::geometry::ColliderHandle;
 use rapier::geometry::ColliderPair;
 
 use crate::bodies::exportable_object::ExportToImport;
@@ -15,9 +16,13 @@ use crate::bodies::exportable_object::ExportableObject;
 use crate::bodies::exportable_object::ImportToExport;
 use crate::bodies::exportable_object::ObjectExportState;
 use crate::bodies::exportable_object::ObjectImportState;
+use crate::bodies::rapier_area::AreaExport;
+use crate::bodies::rapier_body::BodyExport;
 use crate::bodies::rapier_collision_object::IRapierCollisionObject;
 use crate::bodies::rapier_collision_object::RapierCollisionObject;
+use crate::bodies::rapier_collision_object_base::RapierCollisionObjectBaseState;
 use crate::servers::RapierPhysicsServer;
+use crate::servers::rapier_physics_singleton::RapierId;
 use crate::servers::rapier_physics_singleton::physics_data;
 use crate::spaces::rapier_space::SpaceExport;
 use crate::spaces::rapier_space::SpaceImport;
@@ -70,6 +75,75 @@ impl CollatedObjectImportState {
             state: self.state.as_export(),
             shape_owners: export_state_map,
         }
+    }
+}
+/// A stripped-down version of the physics state that only contains deterministic data.
+/// Used for cross-instance state comparison (rollback mismatch detection).
+/// Excludes: physics_server_id, instance_ids, collider_instance_ids.
+#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+struct DeterministicExportState<'a> {
+    rapier_space: &'a SpaceExport<'a>,
+    physics_objects_state: BTreeMap<&'a String, DeterministicObjectState<'a>>,
+}
+#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+struct DeterministicObjectState<'a> {
+    state: DeterministicNodeState<'a>,
+    shape_owners: &'a BTreeMap<String, Vec<ObjectExportState<'a>>>,
+}
+#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+enum DeterministicNodeState<'a> {
+    Body(&'a BodyExport<'a>),
+    Area(DeterministicAreaState<'a>),
+    Other(&'a ObjectExportState<'a>),
+}
+#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+struct DeterministicAreaState<'a> {
+    base_state: &'a RapierCollisionObjectBaseState,
+    // Serialize monitored_objects keys and physics-relevant fields only
+    monitored_collider_pairs: Vec<(&'a (ColliderHandle, ColliderHandle), &'a RapierId, i32)>,
+}
+impl<'a> DeterministicExportState<'a> {
+    fn from_raw(raw: &'a RawExportState<'a>) -> Self {
+        let mut objects = BTreeMap::new();
+        for (path, collated) in &raw.physics_objects_state {
+            let det_state = match &collated.state {
+                ObjectExportState::Body(body) => DeterministicNodeState::Body(body),
+                ObjectExportState::Area(area) => DeterministicAreaState::from_area(area),
+                other => DeterministicNodeState::Other(other),
+            };
+            objects.insert(
+                path,
+                DeterministicObjectState {
+                    state: det_state,
+                    shape_owners: &collated.shape_owners,
+                },
+            );
+        }
+        DeterministicExportState {
+            rapier_space: &raw.rapier_space,
+            physics_objects_state: objects,
+        }
+    }
+}
+impl<'a> DeterministicAreaState<'a> {
+    fn from_area(area: &'a AreaExport<'a>) -> DeterministicNodeState<'a> {
+        let mut pairs: Vec<_> = area
+            .area_state
+            .monitored_objects
+            .iter()
+            .map(|(key, info)| (key, &info.other_collider_id, info.num_contacts))
+            .collect();
+        // Sort for deterministic output (HashMap iteration order is non-deterministic)
+        pairs.sort_by(|a, b| {
+            a.0.0
+                .into_raw_parts()
+                .cmp(&b.0.0.into_raw_parts())
+                .then(a.0.1.into_raw_parts().cmp(&b.0.1.into_raw_parts()))
+        });
+        DeterministicNodeState::Area(DeterministicAreaState {
+            base_state: area.base_state,
+            monitored_collider_pairs: pairs,
+        })
     }
 }
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
@@ -277,6 +351,27 @@ impl StateManager {
             self.serialize_state(raw_state, &format)
         } else {
             Variant::nil()
+        }
+    }
+
+    #[func]
+    /// Exports a deterministic representation of the physics state suitable for cross-instance
+    /// comparison (e.g. rollback netcode mismatch detection). This excludes process-specific
+    /// fields like instance IDs and the physics server counter that differ between Godot instances
+    /// even when the physics simulation is identical.
+    /// The output should NOT be used with import_state — use export_state for save/load.
+    fn export_deterministic_state(&mut self, in_space: Rid) -> PackedByteArray {
+        if let Some(raw_state) = self.fetch_state(in_space) {
+            let deterministic_state = DeterministicExportState::from_raw(&raw_state);
+            match bincode::serialize(&deterministic_state) {
+                Ok(b) => bin_to_packed_byte_array(b),
+                Err(err) => {
+                    godot_error!("Failed to serialize deterministic physics state: {}", err);
+                    PackedByteArray::new()
+                }
+            }
+        } else {
+            PackedByteArray::new()
         }
     }
 

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -1,4 +1,5 @@
 use godot::global::godot_error;
+use rapier::na::ComplexField;
 use rapier::prelude::*;
 
 use crate::joints::rapier_joint_base::RapierJointType;
@@ -10,11 +11,11 @@ impl PhysicsEngine {
     fn godot_spring_to_rapier_accel(stiffness: Real, damping: Real) -> (Real, Real) {
         // Godot stiffness is in N/m, convert to frequency: omega = sqrt(k/m)
         // For AccelerationBased, assume unit mass (m=1)
-        let omega = stiffness.sqrt();
+        let omega: Real = ComplexField::sqrt(stiffness);
         // Calculate damping ratio from Godot damping: zeta = c / (2 * sqrt(k*m))
         // For unit mass: zeta = c / (2 * sqrt(k))
         let damping_ratio = if stiffness > 0.0 {
-            damping / (2.0 * stiffness.sqrt())
+            damping / (2.0 * omega)
         } else {
             0.0
         };

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -1,4 +1,5 @@
 use godot::global::godot_error;
+#[cfg(feature = "dim2")]
 use rapier::na::ComplexField;
 use rapier::prelude::*;
 

--- a/src/rapier_wrapper/shape.rs
+++ b/src/rapier_wrapper/shape.rs
@@ -72,6 +72,7 @@ fn convex_polyline_orientation(points: &[Vector]) -> Option<ConvexPolylineOrient
 }
 #[cfg(feature = "dim2")]
 fn sort_points_counter_clockwise(points: &[Vector]) -> Vec<Vector> {
+    use rapier::na::RealField;
     let mut center = Vector::ZERO;
     for point in points {
         center += *point;
@@ -79,8 +80,8 @@ fn sort_points_counter_clockwise(points: &[Vector]) -> Vec<Vector> {
     center /= points.len() as Real;
     let mut sorted = points.to_vec();
     sorted.sort_by(|a, b| {
-        let angle_a = (a.y - center.y).atan2(a.x - center.x);
-        let angle_b = (b.y - center.y).atan2(b.x - center.x);
+        let angle_a = RealField::atan2(a.y - center.y, a.x - center.x);
+        let angle_b = RealField::atan2(b.y - center.y, b.x - center.x);
         angle_a
             .partial_cmp(&angle_b)
             .unwrap_or(std::cmp::Ordering::Equal)

--- a/src/servers/rapier_physics_server_impl.rs
+++ b/src/servers/rapier_physics_server_impl.rs
@@ -2544,7 +2544,7 @@ impl RapierPhysicsServerImpl {
         let physics_data = physics_data();
         let mut space_to_reset = Rid::Invalid;
         if let Some(mut shape) = physics_data.shapes.remove(&rid) {
-            for (owner, _) in shape.get_base().get_owners() {
+            for owner in shape.get_base().get_owners().keys() {
                 if let Some(body) = physics_data
                     .collision_objects
                     .get_mut(&get_id_rid(*owner, &physics_data.ids))

--- a/src/shapes/rapier_shape_base.rs
+++ b/src/shapes/rapier_shape_base.rs
@@ -1,5 +1,6 @@
+use std::collections::BTreeMap;
+
 use godot::prelude::*;
-use hashbrown::HashMap;
 use rapier::prelude::SharedShape;
 
 use crate::bodies::exportable_object::ExportToImport;
@@ -50,14 +51,7 @@ impl ImportToExport for ShapeImport {
 #[derive(PartialEq, Clone, Debug, Default)]
 pub struct RapierShapeState {
     aabb: Rect,
-    #[cfg_attr(
-        feature = "serde-serialize",
-        serde(
-            serialize_with = "rapier::utils::serde::serialize_to_vec_tuple",
-            deserialize_with = "rapier::utils::serde::deserialize_from_vec_tuple"
-        )
-    )]
-    owners: HashMap<RapierId, i32>,
+    owners: BTreeMap<RapierId, i32>,
     id: RapierId,
 }
 #[derive(Debug)]
@@ -94,7 +88,7 @@ impl RapierShapeBase {
     }
 
     pub fn call_shape_changed(
-        owners: HashMap<RapierId, i32>,
+        owners: BTreeMap<RapierId, i32>,
         shape_id: RapierId,
         physics_data: &mut PhysicsData,
     ) {
@@ -132,7 +126,7 @@ impl RapierShapeBase {
         }
     }
 
-    pub fn get_owners(&self) -> &HashMap<RapierId, i32> {
+    pub fn get_owners(&self) -> &BTreeMap<RapierId, i32> {
         &self.state.owners
     }
 

--- a/src/spaces/rapier_space_callbacks.rs
+++ b/src/spaces/rapier_space_callbacks.rs
@@ -147,12 +147,12 @@ impl RapierSpace {
             .get_removed_collider_info(&collider_handle1)
         {
             body_id1 = removed_collider_info_1.rb_id;
-            instance_id1 = removed_collider_info_1.instance_id;
+            instance_id1 = removed_collider_info_1.rb_id;
             type1 = removed_collider_info_1.collision_object_type;
             shape1 = removed_collider_info_1.shape_index;
         } else if let Some(body1) = physics_collision_objects.get(&p_object1) {
             body_id1 = body1.get_base().get_id();
-            instance_id1 = body1.get_base().get_instance_id();
+            instance_id1 = body1.get_base().get_id();
             type1 = body1.get_base().get_type();
         }
         if let Some(removed_collider_info_2) = self
@@ -160,12 +160,12 @@ impl RapierSpace {
             .get_removed_collider_info(&collider_handle2)
         {
             body_id2 = removed_collider_info_2.rb_id;
-            instance_id2 = removed_collider_info_2.instance_id;
+            instance_id2 = removed_collider_info_2.rb_id;
             type2 = removed_collider_info_2.collision_object_type;
             shape2 = removed_collider_info_2.shape_index;
         } else if let Some(body2) = physics_collision_objects.get(&p_object2) {
             body_id2 = body2.get_base().get_id();
-            instance_id2 = body2.get_base().get_instance_id();
+            instance_id2 = body2.get_base().get_id();
             type2 = body2.get_base().get_type();
         }
         if event_info.is_sensor {
@@ -320,7 +320,6 @@ impl RapierSpace {
                     body1.to_add_static_constant_angular_velocity(static_angvelocity_2);
                 }
                 if body1.can_report_contacts() {
-                    let instance_id2 = body2.get_base().get_instance_id();
                     body1.add_contact(
                         vector_to_godot(pos1),
                         vector_to_godot(-normal),
@@ -329,14 +328,13 @@ impl RapierSpace {
                         vector_to_godot(vel_pos1),
                         vector_to_godot(pos2),
                         shape2 as i32,
-                        instance_id2,
+                        body2.get_base().get_id(),
                         body2.get_base().get_id(),
                         vector_to_godot(vel_pos2),
                         impulse,
                     );
                 }
                 if body2.can_report_contacts() {
-                    let instance_id1 = body1.get_base().get_instance_id();
                     body2.add_contact(
                         vector_to_godot(pos2),
                         vector_to_godot(normal),
@@ -345,7 +343,7 @@ impl RapierSpace {
                         vector_to_godot(vel_pos2),
                         vector_to_godot(pos1),
                         shape1 as i32,
-                        instance_id1,
+                        body1.get_base().get_id(),
                         body1.get_base().get_id(),
                         vector_to_godot(vel_pos1),
                         -impulse,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use godot::classes::*;
 use godot::prelude::*;
 use rapier::math::Rotation;
+#[cfg(feature = "dim2")]
 use rapier::na::ComplexField;
 #[cfg(feature = "single")]
 pub type PackedFloatArray = PackedFloat32Array;
@@ -145,7 +146,6 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
     // We need to compute the delta rotation and apply it to the existing basis vectors.
     let cos_new = rotation.re;
     let sin_new = rotation.im;
-
     // Extract current rotation deterministically from the 'a' basis vector.
     let ax = transform.a.x;
     let ay = transform.a.y;
@@ -155,13 +155,11 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
     } else {
         (1.0, 0.0)
     };
-
     // Compute delta rotation: new * inverse(old)
     // inverse of (cos, sin) = (cos, -sin) for unit complex
     // (cos_new + i*sin_new) * (cos_old - i*sin_old)
     let cos_delta = cos_new * cos_old + sin_new * sin_old;
     let sin_delta = sin_new * cos_old - cos_new * sin_old;
-
     // Apply delta rotation to both basis vectors to preserve skew and scale.
     // Rotation of vector (x, y) by angle: (x*cos - y*sin, x*sin + y*cos)
     let mut a = Vector2::new(
@@ -172,7 +170,6 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
         transform.b.x * cos_delta - transform.b.y * sin_delta,
         transform.b.x * sin_delta + transform.b.y * cos_delta,
     );
-
     // Re-normalize to prevent scale drift from repeated rotations.
     // Use deterministic sqrt via ComplexField (backed by libm with enhanced-determinism).
     let new_len_a: real = ComplexField::sqrt(a.x * a.x + a.y * a.y);
@@ -188,7 +185,6 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
         let correction_b = len_b / new_len_b;
         b *= correction_b;
     }
-
     Transform2D { a, b, origin }
 }
 #[cfg(feature = "dim3")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use godot::classes::*;
 use godot::prelude::*;
 use rapier::math::Rotation;
+use rapier::na::ComplexField;
 #[cfg(feature = "single")]
 pub type PackedFloatArray = PackedFloat32Array;
 #[cfg(feature = "double")]
@@ -117,30 +118,77 @@ pub fn world_to_local_no_scale(transform: &Transform, world_pos: Vector) -> Vect
         // Degenerate scale, return as-is
         return transform.affine_inverse() * world_pos;
     }
-    // Remove scale from the transform
-    let rotation = transform.rotation();
+    // Extract rotation deterministically from basis vectors
+    let ax = transform.a.x;
+    let ay = transform.a.y;
+    let len: real = ComplexField::sqrt(ax * ax + ay * ay);
+    let (cos_r, sin_r) = if len > 0.0 {
+        (ax / len, ay / len)
+    } else {
+        (1.0, 0.0)
+    };
+    // Build a unit-scale transform from the deterministic rotation
     let origin = transform.origin;
-    let transform_no_scale = Transform::from_angle_scale_skew_origin(
-        rotation,
-        Vector::new(1.0, 1.0),
-        transform.skew(),
+    let transform_no_scale = Transform2D {
+        a: Vector2::new(cos_r, sin_r),
+        b: Vector2::new(-sin_r, cos_r),
         origin,
-    );
+    };
     transform_no_scale.affine_inverse() * world_pos
 }
 #[cfg(feature = "dim2")]
 pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vector) -> Transform {
-    let delta_rotation = rotation.angle() - transform.rotation();
-    let scale_x = transform.a.length();
-    let scale_y = transform.b.length();
-    let mut a = transform.a.rotated(delta_rotation);
-    let mut b = transform.b.rotated(delta_rotation);
-    if !scale_x.is_zero_approx() {
-        a *= scale_x / a.length();
+    // Use deterministic math to avoid platform-dependent transcendental functions.
+    // This is critical for cross-platform determinism with the enhanced-determinism feature.
+    //
+    // The rotation is a UnitComplex (cos θ, sin θ) from rapier — already deterministic.
+    // We need to compute the delta rotation and apply it to the existing basis vectors.
+    let cos_new = rotation.re;
+    let sin_new = rotation.im;
+
+    // Extract current rotation deterministically from the 'a' basis vector.
+    let ax = transform.a.x;
+    let ay = transform.a.y;
+    let len_a: real = ComplexField::sqrt(ax * ax + ay * ay);
+    let (cos_old, sin_old) = if len_a > 0.0 {
+        (ax / len_a, ay / len_a)
+    } else {
+        (1.0, 0.0)
+    };
+
+    // Compute delta rotation: new * inverse(old)
+    // inverse of (cos, sin) = (cos, -sin) for unit complex
+    // (cos_new + i*sin_new) * (cos_old - i*sin_old)
+    let cos_delta = cos_new * cos_old + sin_new * sin_old;
+    let sin_delta = sin_new * cos_old - cos_new * sin_old;
+
+    // Apply delta rotation to both basis vectors to preserve skew and scale.
+    // Rotation of vector (x, y) by angle: (x*cos - y*sin, x*sin + y*cos)
+    let mut a = Vector2::new(
+        transform.a.x * cos_delta - transform.a.y * sin_delta,
+        transform.a.x * sin_delta + transform.a.y * cos_delta,
+    );
+    let mut b = Vector2::new(
+        transform.b.x * cos_delta - transform.b.y * sin_delta,
+        transform.b.x * sin_delta + transform.b.y * cos_delta,
+    );
+
+    // Re-normalize to prevent scale drift from repeated rotations.
+    // Use deterministic sqrt via ComplexField (backed by libm with enhanced-determinism).
+    let new_len_a: real = ComplexField::sqrt(a.x * a.x + a.y * a.y);
+    if !len_a.is_zero_approx() && !new_len_a.is_zero_approx() {
+        let correction_a = len_a / new_len_a;
+        a *= correction_a;
     }
-    if !scale_y.is_zero_approx() {
-        b *= scale_y / b.length();
+    let bx = transform.b.x;
+    let by = transform.b.y;
+    let len_b: real = ComplexField::sqrt(bx * bx + by * by);
+    let new_len_b: real = ComplexField::sqrt(b.x * b.x + b.y * b.y);
+    if !len_b.is_zero_approx() && !new_len_b.is_zero_approx() {
+        let correction_b = len_b / new_len_b;
+        b *= correction_b;
     }
+
     Transform2D { a, b, origin }
 }
 #[cfg(feature = "dim3")]
@@ -162,8 +210,19 @@ pub fn transform_rotation_rapier(transform: &godot::builtin::Transform3D) -> Rot
 }
 #[cfg(feature = "dim2")]
 pub fn transform_rotation_rapier(transform: &godot::builtin::Transform2D) -> Rotation {
-    let angle = transform.rotation();
-    Rotation::from_angle(angle)
+    // Instead of calling transform.rotation() which uses Godot's platform-dependent atan2,
+    // extract the rotation directly from the basis vectors using deterministic math.
+    // The 'a' column of Transform2D is (cos*scale_x, sin*scale_x).
+    // We need the unit vector direction, which gives us (cos, sin) for the Rotation.
+    let ax = transform.a.x;
+    let ay = transform.a.y;
+    let len: real = ComplexField::sqrt(ax * ax + ay * ay);
+    if len > 0.0 {
+        // Rotation (UnitComplex) stores (cos, sin) = (re, im)
+        Rotation::from_cos_sin_unchecked(ax / len, ay / len)
+    } else {
+        Rotation::identity()
+    }
 }
 #[cfg(feature = "dim3")]
 pub fn basis_to_rapier(basis: godot::builtin::Basis) -> Rotation {


### PR DESCRIPTION
This fixes https://github.com/appsinacup/godot-rapier-physics/issues/558 and partially https://github.com/appsinacup/godot-rapier-physics/issues/534

Basically the main issue was that non cross platform deterministic math was applied in various places. I've fixed those I've seen, hoping I did not missed any.

For the #534 issue, I've reused the deterministic RapierId for internal state IDs since they are used in state hash. Non-deterministic Godot internal IDs are then retrieved on the fly thanks to these rapier IDs.