### PR TITLE
enhanced-determinism feature does not guarantee cross-platform determinism for 3D

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -32,6 +32,22 @@ runs:
         rustup toolchain install "$TOOLCHAIN"
         rustup component add rust-src --toolchain "$TOOLCHAIN"
         rustup target add ${{ inputs.arch }} --toolchain "$TOOLCHAIN"
+    - name: Set deterministic rustflags for arm64
+      shell: sh
+      run: |
+        # Disable FMA contraction on arm64 targets when building with enhanced-determinism.
+        # FMA (fused multiply-add) produces different rounding than separate mul+add,
+        # causing cross-platform divergence between arm64 and x86_64.
+        case "${{ inputs.arch }}" in
+          aarch64-*)
+            case "${{ inputs.features }}" in
+              *enhanced-determinism*)
+                echo "CARGO_ENCODED_RUSTFLAGS=-Cllvm-args=--fp-contract=off" >> "$GITHUB_ENV"
+                echo "Enabled --fp-contract=off for deterministic arm64 build"
+                ;;
+            esac
+            ;;
+        esac
     - name: Build
       shell: sh
       run: |
@@ -51,7 +67,14 @@ runs:
         mkdir -p target/release
         TOOLCHAIN=$(grep -E '^channel' rust-toolchain.toml | sed -E 's/channel = "(.*)"/\1/')
         rustup target add aarch64-apple-darwin --toolchain "$TOOLCHAIN"
-        cargo +"$TOOLCHAIN" build --target=aarch64-apple-darwin --profile=${{ inputs.profile }} --features="${{ inputs.features }},api-custom" ${{ inputs.extra_flags }} --no-default-features
+        # Disable FMA for arm64 enhanced-determinism builds
+        EXTRA_RUSTFLAGS=""
+        case "${{ inputs.features }}" in
+          *enhanced-determinism*)
+            EXTRA_RUSTFLAGS="-Cllvm-args=--fp-contract=off"
+            ;;
+        esac
+        CARGO_ENCODED_RUSTFLAGS="$EXTRA_RUSTFLAGS" cargo +"$TOOLCHAIN" build --target=aarch64-apple-darwin --profile=${{ inputs.profile }} --features="${{ inputs.features }},api-custom" ${{ inputs.extra_flags }} --no-default-features
         lipo -create -output target/release/libgodot_rapier.dylib target/aarch64-apple-darwin/${{ inputs.profile }}/libgodot_rapier.dylib target/x86_64-apple-darwin/${{ inputs.profile }}/libgodot_rapier.dylib
     - name: Move Static Libs macOS
       shell: sh

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -32,22 +32,6 @@ runs:
         rustup toolchain install "$TOOLCHAIN"
         rustup component add rust-src --toolchain "$TOOLCHAIN"
         rustup target add ${{ inputs.arch }} --toolchain "$TOOLCHAIN"
-    - name: Set deterministic rustflags for arm64
-      shell: sh
-      run: |
-        # Disable FMA contraction on arm64 targets when building with enhanced-determinism.
-        # FMA (fused multiply-add) produces different rounding than separate mul+add,
-        # causing cross-platform divergence between arm64 and x86_64.
-        case "${{ inputs.arch }}" in
-          aarch64-*)
-            case "${{ inputs.features }}" in
-              *enhanced-determinism*)
-                echo "CARGO_ENCODED_RUSTFLAGS=-Cllvm-args=--fp-contract=off" >> "$GITHUB_ENV"
-                echo "Enabled --fp-contract=off for deterministic arm64 build"
-                ;;
-            esac
-            ;;
-        esac
     - name: Build
       shell: sh
       run: |
@@ -67,14 +51,7 @@ runs:
         mkdir -p target/release
         TOOLCHAIN=$(grep -E '^channel' rust-toolchain.toml | sed -E 's/channel = "(.*)"/\1/')
         rustup target add aarch64-apple-darwin --toolchain "$TOOLCHAIN"
-        # Disable FMA for arm64 enhanced-determinism builds
-        EXTRA_RUSTFLAGS=""
-        case "${{ inputs.features }}" in
-          *enhanced-determinism*)
-            EXTRA_RUSTFLAGS="-Cllvm-args=--fp-contract=off"
-            ;;
-        esac
-        CARGO_ENCODED_RUSTFLAGS="$EXTRA_RUSTFLAGS" cargo +"$TOOLCHAIN" build --target=aarch64-apple-darwin --profile=${{ inputs.profile }} --features="${{ inputs.features }},api-custom" ${{ inputs.extra_flags }} --no-default-features
+        cargo +"$TOOLCHAIN" build --target=aarch64-apple-darwin --profile=${{ inputs.profile }} --features="${{ inputs.features }},api-custom" ${{ inputs.extra_flags }} --no-default-features
         lipo -create -output target/release/libgodot_rapier.dylib target/aarch64-apple-darwin/${{ inputs.profile }}/libgodot_rapier.dylib target/x86_64-apple-darwin/${{ inputs.profile }}/libgodot_rapier.dylib
     - name: Move Static Libs macOS
       shell: sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ name = "godot-rapier"
 version = "0.8.35"
 dependencies = [
  "bincode",
+ "glamx",
  "godot",
  "hashbrown 0.16.1",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ single = []
 double = ["godot/double-precision"]
 api-custom = ["godot/api-custom"]
 register-docs = ["godot/register-docs"]
-enhanced-determinism = ["rapier2d?/enhanced-determinism", "rapier2d-f64?/enhanced-determinism", "rapier3d?/enhanced-determinism", "rapier3d-f64?/enhanced-determinism"]
+enhanced-determinism = ["rapier2d?/enhanced-determinism", "rapier2d-f64?/enhanced-determinism", "rapier3d?/enhanced-determinism", "rapier3d-f64?/enhanced-determinism", "glamx/scalar-math"]
 serde-serialize = ["serde", "hashbrown/serde", "bincode", "serde_json", "godot/serde", "rapier2d?/serde-serialize", "rapier2d-f64?/serde-serialize", "rapier3d?/serde-serialize", "rapier3d-f64?/serde-serialize" ]
 # Note: SIMD disabled for f64 builds due to upstream rapier bugs with f64 SIMD implementation
 # simd-nightly = ["rapier2d/simd-nightly", "rapier2d-f64/simd-nightly", "rapier3d/simd-nightly", "rapier3d-f64/simd-nightly"]
@@ -46,6 +46,7 @@ num_cpus = { version = "1", optional = true }
 
 # Disabled for now "safeguards-release-disengaged"] }
 godot = { version = "0.5.3" }
+glamx = { version = "0.3", default-features = false }
 
 rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master", optional = true }
 rapier2d-f64 = { git = "https://github.com/dimforge/rapier", branch = "master", optional = true}

--- a/src/joints/rapier_damped_spring_joint_2d.rs
+++ b/src/joints/rapier_damped_spring_joint_2d.rs
@@ -49,7 +49,7 @@ impl RapierDampedSpringJoint2D {
             world_to_local_no_scale(&body_a.get_base().get_transform(), p_anchor_a);
         let rapier_anchor_b =
             world_to_local_no_scale(&body_b.get_base().get_transform(), p_anchor_b);
-        let rest_length = (p_anchor_a - p_anchor_b).length();
+        let rest_length = vector_length(p_anchor_a - p_anchor_b);
         let space_handle = body_a.get_base().get_space_id();
         let space_id = body_a.get_base().get_space_id();
         let handle = physics_engine.joint_create_spring(

--- a/src/joints/rapier_groove_joint_2d.rs
+++ b/src/joints/rapier_groove_joint_2d.rs
@@ -44,7 +44,7 @@ impl RapierGrooveJoint2D {
         let point_a_1 = world_to_local_no_scale(&base_a.get_transform(), p_a_groove1);
         let point_a_2 = world_to_local_no_scale(&base_a.get_transform(), p_a_groove2);
         let axis = vector_normalized(point_a_2 - point_a_1);
-        let length = (point_a_2 - point_a_1).length();
+        let length = vector_length(point_a_2 - point_a_1);
         let rapier_axis = vector_to_rapier(axis);
         let rapier_limits = vector_to_rapier(Vector2::new(0.0, length));
         let rapier_anchor_a = vector_to_rapier(point_a_1);

--- a/src/rapier_wrapper/shape.rs
+++ b/src/rapier_wrapper/shape.rs
@@ -127,12 +127,11 @@ pub fn shape_info_from_body_shape(shape_handle: ShapeHandle, transform: Transfor
 }
 #[cfg(feature = "dim3")]
 pub fn shape_info_from_body_shape(shape_handle: ShapeHandle, transform: Transform) -> ShapeInfo {
-    let quaternion = transform.basis.get_quaternion();
-    let rotation = Rotation::from_xyzw(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+    let rotation = types::basis_to_rapier(transform.basis);
     ShapeInfo {
         handle: shape_handle,
         transform: Pose::from_parts(vector_to_rapier(transform.origin), rotation),
-        scale: vector_to_rapier(transform.basis.get_scale()),
+        scale: vector_to_rapier(types::transform_scale(&transform)),
     }
 }
 impl PhysicsEngine {

--- a/src/servers/rapier_physics_server_impl.rs
+++ b/src/servers/rapier_physics_server_impl.rs
@@ -1941,26 +1941,26 @@ impl RapierPhysicsServerImpl {
             // The hinge axis should be the X-axis in the local frame
             // Construct a basis where X-axis is aligned with the given axis
             let basis_a = if axis_a.length_squared() > 0.0 {
-                let x_axis = axis_a.normalized();
+                let x_axis = vector_normalized(axis_a);
                 // Choose an arbitrary perpendicular vector for Y
                 let y_axis = if x_axis.abs().dot(Vector3::UP) < 0.99 {
-                    x_axis.cross(Vector3::UP).normalized()
+                    vector_normalized(x_axis.cross(Vector3::UP))
                 } else {
-                    x_axis.cross(Vector3::RIGHT).normalized()
+                    vector_normalized(x_axis.cross(Vector3::RIGHT))
                 };
-                let z_axis = x_axis.cross(y_axis).normalized();
+                let z_axis = vector_normalized(x_axis.cross(y_axis));
                 godot::prelude::Basis::from_cols(x_axis, y_axis, z_axis)
             } else {
                 godot::prelude::Basis::IDENTITY
             };
             let basis_b = if axis_b.length_squared() > 0.0 {
-                let x_axis = axis_b.normalized();
+                let x_axis = vector_normalized(axis_b);
                 let y_axis = if x_axis.abs().dot(Vector3::UP) < 0.99 {
-                    x_axis.cross(Vector3::UP).normalized()
+                    vector_normalized(x_axis.cross(Vector3::UP))
                 } else {
-                    x_axis.cross(Vector3::RIGHT).normalized()
+                    vector_normalized(x_axis.cross(Vector3::RIGHT))
                 };
-                let z_axis = x_axis.cross(y_axis).normalized();
+                let z_axis = vector_normalized(x_axis.cross(y_axis));
                 godot::prelude::Basis::from_cols(x_axis, y_axis, z_axis)
             } else {
                 godot::prelude::Basis::IDENTITY

--- a/src/spaces/rapier_direct_space_state_impl.rs
+++ b/src/spaces/rapier_direct_space_state_impl.rs
@@ -124,7 +124,7 @@ impl RapierDirectSpaceStateImpl {
             space.get_state().get_id(),
             vector_to_rapier(from),
             vector_to_rapier(dir),
-            end.length(),
+            vector_length(end),
             collide_with_bodies,
             collide_with_areas,
             hit_from_inside,

--- a/src/spaces/rapier_space_body_helper.rs
+++ b/src/spaces/rapier_space_body_helper.rs
@@ -75,12 +75,12 @@ fn blocked_motion_tolerance(margin: Real) -> Real {
 }
 fn clamp_near_zero_safe_motion(motion: Vector, margin: Real, safe_fraction: &mut Real) {
     let tolerance = blocked_motion_tolerance(margin);
-    if *safe_fraction < 1.0 && motion.length() * *safe_fraction < tolerance {
+    if *safe_fraction < 1.0 && vector_length(motion) * *safe_fraction < tolerance {
         *safe_fraction = 0.0;
     }
 }
 fn clamp_near_zero_blocked_travel(motion: Vector, margin: Real, travel: &mut Vector) {
-    if motion.dot(*travel) > 0.0 && travel.length() < blocked_motion_tolerance(margin) {
+    if motion.dot(*travel) > 0.0 && vector_length(*travel) < blocked_motion_tolerance(margin) {
         *travel = Vector::default();
     }
 }
@@ -228,7 +228,7 @@ fn finish_small_body_motion(
     motion: Vector,
     result: &mut PhysicsServerExtensionMotionResult,
 ) -> bool {
-    if motion.length() >= MIN_MOTION_THRESHOLD {
+    if vector_length(motion) >= MIN_MOTION_THRESHOLD {
         return false;
     }
     result.travel = Vector::default();
@@ -353,14 +353,13 @@ impl RapierSpace {
     ) -> bool {
         reset_body_motion_result(result);
         let mut body_transform = from; // Because body_transform needs to be modified during recovery
-        let is_small_motion = motion.length() < MIN_MOTION_THRESHOLD;
+        let is_small_motion = vector_length(motion) < MIN_MOTION_THRESHOLD;
         // Step 1: recover motion.
         // Expand the body colliders by the margin (grow) and check if now it collides with a collider,
         // if yes, "recover" / "push" out of this collider
         let mut recover_motion = Vector::default();
         let margin = Real::max(margin, TEST_MOTION_MARGIN);
-        let min_allowed_depth = motion
-            .length()
+        let min_allowed_depth = vector_length(motion)
             .min(margin * TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR);
         let mut excluded_shape_pairs = [ExcludedShapePair::default(); MAX_EXCLUDED_SHAPE_PAIRS];
         let mut excluded_shape_pair_count = 0;
@@ -655,7 +654,7 @@ impl RapierSpace {
             let recover_motion =
                 recover_motion_from_contacts(&sr, &priorities, contact_count, min_contact_depth);
             // Break if recovery motion is too small to be meaningful
-            if recover_motion.length() < MIN_RECOVERY_THRESHOLD {
+            if vector_length(recover_motion) < MIN_RECOVERY_THRESHOLD {
                 recovered = false;
                 break;
             }
@@ -1179,7 +1178,7 @@ fn one_way_valid_depth(
 ) -> f32 {
     let mut valid_depth = owc_margin.max(motion_margin);
     let platform_motion = platform_linear_velocity * last_step;
-    let platform_motion_len = platform_motion.length();
+    let platform_motion_len = vector_length(platform_motion);
     if !platform_motion_len.is_zero_approx() {
         valid_depth +=
             platform_motion_len * vector_normalized(platform_motion).dot(-valid_dir).max(0.0);
@@ -1408,14 +1407,14 @@ mod tests {
     #[test]
     fn clamp_near_zero_safe_motion_sets_sub_epsilon_travel_to_zero() {
         let motion = x_motion(10.0);
-        let mut safe_fraction = (MOTION_EPSILON * 0.5) / motion.length();
+        let mut safe_fraction = (MOTION_EPSILON * 0.5) / vector_length(motion);
         clamp_near_zero_safe_motion(motion, 0.0, &mut safe_fraction);
         assert_eq!(safe_fraction, 0.0);
     }
     #[test]
     fn clamp_near_zero_safe_motion_keeps_meaningful_travel() {
         let motion = x_motion(10.0);
-        let mut safe_fraction = (blocked_motion_tolerance(0.0) * 2.0) / motion.length();
+        let mut safe_fraction = (blocked_motion_tolerance(0.0) * 2.0) / vector_length(motion);
         let expected = safe_fraction;
         clamp_near_zero_safe_motion(motion, 0.0, &mut safe_fraction);
         assert_eq!(safe_fraction, expected);
@@ -1423,7 +1422,7 @@ mod tests {
     #[test]
     fn clamp_near_zero_safe_motion_uses_margin_relative_tolerance() {
         let motion = x_motion(10.0);
-        let mut safe_fraction = 0.003 / motion.length();
+        let mut safe_fraction = 0.003 / vector_length(motion);
         clamp_near_zero_safe_motion(motion, 0.08, &mut safe_fraction);
         assert_eq!(safe_fraction, 0.0);
     }

--- a/src/spaces/rapier_space_body_helper.rs
+++ b/src/spaces/rapier_space_body_helper.rs
@@ -359,8 +359,8 @@ impl RapierSpace {
         // if yes, "recover" / "push" out of this collider
         let mut recover_motion = Vector::default();
         let margin = Real::max(margin, TEST_MOTION_MARGIN);
-        let min_allowed_depth = vector_length(motion)
-            .min(margin * TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR);
+        let min_allowed_depth =
+            vector_length(motion).min(margin * TEST_MOTION_MIN_CONTACT_DEPTH_FACTOR);
         let mut excluded_shape_pairs = [ExcludedShapePair::default(); MAX_EXCLUDED_SHAPE_PAIRS];
         let mut excluded_shape_pair_count = 0;
         let recovered = self.body_motion_recover(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,6 @@
 use godot::classes::*;
 use godot::prelude::*;
 use rapier::math::Rotation;
-#[cfg(feature = "dim2")]
 use rapier::na::ComplexField;
 #[cfg(feature = "single")]
 pub type PackedFloatArray = PackedFloat32Array;
@@ -67,7 +66,25 @@ pub type PhysicsServerExtensionRayResult = native::PhysicsServer3DExtensionRayRe
 pub type PhysicsServerExtensionShapeRestInfo = native::PhysicsServer3DExtensionShapeRestInfo;
 #[cfg(feature = "dim3")]
 pub fn transform_scale(transform: &Transform) -> Vector {
-    transform.basis.get_scale()
+    // Deterministic scale extraction: compute column lengths using ComplexField::sqrt
+    // instead of Godot's platform-dependent get_scale().
+    let basis = &transform.basis;
+    let col0 = basis.col_a();
+    let col1 = basis.col_b();
+    let col2 = basis.col_c();
+    let sx: real =
+        ComplexField::sqrt(col0.x * col0.x + col0.y * col0.y + col0.z * col0.z);
+    let sy: real =
+        ComplexField::sqrt(col1.x * col1.x + col1.y * col1.y + col1.z * col1.z);
+    let sz: real =
+        ComplexField::sqrt(col2.x * col2.x + col2.y * col2.y + col2.z * col2.z);
+    // Detect negative scale via determinant sign
+    let det = basis.determinant();
+    if det < 0.0 {
+        Vector3::new(-sx, sy, sz)
+    } else {
+        Vector3::new(sx, sy, sz)
+    }
 }
 #[derive(Clone, GodotConvert, Var, Export, Debug)]
 #[godot(via = GString)]
@@ -189,20 +206,40 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
 }
 #[cfg(feature = "dim3")]
 pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vector) -> Transform {
-    use godot::builtin::Basis;
-    let new_transform = Transform::new(
-        Basis::from_quaternion(Quaternion::new(
-            rotation.x, rotation.y, rotation.z, rotation.w,
-        )),
-        origin,
+    // Deterministic basis construction from quaternion.
+    // Avoids Godot's Basis::from_quaternion which may use platform-dependent math internally.
+    let x = rotation.x;
+    let y = rotation.y;
+    let z = rotation.z;
+    let w = rotation.w;
+    // Rotation matrix from quaternion (column-major):
+    // col0 = (1-2(y²+z²), 2(xy+wz), 2(xz-wy))
+    // col1 = (2(xy-wz), 1-2(x²+z²), 2(yz+wx))
+    // col2 = (2(xz+wy), 2(yz-wx), 1-2(x²+y²))
+    let xx = x * x;
+    let yy = y * y;
+    let zz = z * z;
+    let xy = x * y;
+    let xz = x * z;
+    let yz = y * z;
+    let wx = w * x;
+    let wy = w * y;
+    let wz = w * z;
+    let col0 = Vector3::new(1.0 - 2.0 * (yy + zz), 2.0 * (xy + wz), 2.0 * (xz - wy));
+    let col1 = Vector3::new(2.0 * (xy - wz), 1.0 - 2.0 * (xx + zz), 2.0 * (yz + wx));
+    let col2 = Vector3::new(2.0 * (xz + wy), 2.0 * (yz - wx), 1.0 - 2.0 * (xx + yy));
+    // Apply scale from the original transform deterministically
+    let scale = transform_scale(transform);
+    let basis = godot::builtin::Basis::from_cols(
+        col0 * scale.x,
+        col1 * scale.y,
+        col2 * scale.z,
     );
-    let scale = transform.basis.get_scale();
-    new_transform.scaled_local(scale)
+    Transform::new(basis, origin)
 }
 #[cfg(feature = "dim3")]
 pub fn transform_rotation_rapier(transform: &godot::builtin::Transform3D) -> Rotation {
-    let quaternion = transform.basis.get_quaternion();
-    Rotation::from_xyzw(quaternion.x, quaternion.y, quaternion.z, quaternion.w)
+    basis_to_rapier(transform.basis)
 }
 #[cfg(feature = "dim2")]
 pub fn transform_rotation_rapier(transform: &godot::builtin::Transform2D) -> Rotation {
@@ -222,12 +259,105 @@ pub fn transform_rotation_rapier(transform: &godot::builtin::Transform2D) -> Rot
 }
 #[cfg(feature = "dim3")]
 pub fn basis_to_rapier(basis: godot::builtin::Basis) -> Rotation {
-    let quaternion = basis.get_quaternion();
-    Rotation::from_xyzw(quaternion.x, quaternion.y, quaternion.z, quaternion.w)
+    // Deterministic quaternion extraction from a rotation matrix using Shepperd's method.
+    // Uses ComplexField::sqrt (backed by libm with enhanced-determinism) instead of
+    // platform-dependent sqrt.
+    //
+    // First, remove scale from the basis to get a pure rotation matrix.
+    let col0 = basis.col_a();
+    let col1 = basis.col_b();
+    let col2 = basis.col_c();
+    let sx: real = ComplexField::sqrt(col0.x * col0.x + col0.y * col0.y + col0.z * col0.z);
+    let sy: real = ComplexField::sqrt(col1.x * col1.x + col1.y * col1.y + col1.z * col1.z);
+    let sz: real = ComplexField::sqrt(col2.x * col2.x + col2.y * col2.y + col2.z * col2.z);
+    if sx == 0.0 || sy == 0.0 || sz == 0.0 {
+        return Rotation::from_xyzw(0.0, 0.0, 0.0, 1.0);
+    }
+    // Normalize columns to get rotation matrix, accounting for negative determinant
+    let det = basis.determinant();
+    let sign = if det < 0.0 { -1.0 } else { 1.0 };
+    let inv_sx = sign / sx;
+    let inv_sy = 1.0 / sy;
+    let inv_sz = 1.0 / sz;
+    // Rotation matrix elements (row-major access: m[row][col])
+    // Godot's Basis stores columns, so col_a() = first column, etc.
+    // m00 = col0.x/sx, m10 = col0.y/sx, m20 = col0.z/sx
+    // m01 = col1.x/sy, m11 = col1.y/sy, m21 = col1.z/sy
+    // m02 = col2.x/sz, m12 = col2.y/sz, m22 = col2.z/sz
+    let m00 = col0.x * inv_sx;
+    let m10 = col0.y * inv_sx;
+    let m20 = col0.z * inv_sx;
+    let m01 = col1.x * inv_sy;
+    let m11 = col1.y * inv_sy;
+    let m21 = col1.z * inv_sy;
+    let m02 = col2.x * inv_sz;
+    let m12 = col2.y * inv_sz;
+    let m22 = col2.z * inv_sz;
+    // Shepperd's method: find the largest quaternion component to avoid division by near-zero.
+    let trace = m00 + m11 + m22;
+    let (x, y, z, w);
+    if trace > 0.0 {
+        let s: real = ComplexField::sqrt(trace + 1.0) * 2.0; // s = 4*w
+        w = 0.25 * s;
+        x = (m21 - m12) / s;
+        y = (m02 - m20) / s;
+        z = (m10 - m01) / s;
+    } else if m00 > m11 && m00 > m22 {
+        let s: real = ComplexField::sqrt(1.0 + m00 - m11 - m22) * 2.0; // s = 4*x
+        w = (m21 - m12) / s;
+        x = 0.25 * s;
+        y = (m01 + m10) / s;
+        z = (m02 + m20) / s;
+    } else if m11 > m22 {
+        let s: real = ComplexField::sqrt(1.0 + m11 - m00 - m22) * 2.0; // s = 4*y
+        w = (m02 - m20) / s;
+        x = (m01 + m10) / s;
+        y = 0.25 * s;
+        z = (m12 + m21) / s;
+    } else {
+        let s: real = ComplexField::sqrt(1.0 + m22 - m00 - m11) * 2.0; // s = 4*z
+        w = (m10 - m01) / s;
+        x = (m02 + m20) / s;
+        y = (m12 + m21) / s;
+        z = 0.25 * s;
+    }
+    // Normalize the quaternion deterministically
+    let len: real = ComplexField::sqrt(x * x + y * y + z * z + w * w);
+    if len > 0.0 {
+        Rotation::from_xyzw(x / len, y / len, z / len, w / len)
+    } else {
+        Rotation::from_xyzw(0.0, 0.0, 0.0, 1.0)
+    }
+}
+pub fn vector_length(vector: Vector) -> real {
+    #[cfg(feature = "dim2")]
+    {
+        ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y)
+    }
+    #[cfg(feature = "dim3")]
+    {
+        ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+    }
 }
 pub fn vector_normalized(vector: Vector) -> Vector {
     if vector != Vector::ZERO {
-        return vector.normalized();
+        #[cfg(feature = "dim2")]
+        {
+            let len: real =
+                ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y);
+            if len > 0.0 {
+                return Vector2::new(vector.x / len, vector.y / len);
+            }
+        }
+        #[cfg(feature = "dim3")]
+        {
+            let len: real = ComplexField::sqrt(
+                vector.x * vector.x + vector.y * vector.y + vector.z * vector.z,
+            );
+            if len > 0.0 {
+                return Vector3::new(vector.x / len, vector.y / len, vector.z / len);
+            }
+        }
     }
     Vector::ZERO
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,12 +72,9 @@ pub fn transform_scale(transform: &Transform) -> Vector {
     let col0 = basis.col_a();
     let col1 = basis.col_b();
     let col2 = basis.col_c();
-    let sx: real =
-        ComplexField::sqrt(col0.x * col0.x + col0.y * col0.y + col0.z * col0.z);
-    let sy: real =
-        ComplexField::sqrt(col1.x * col1.x + col1.y * col1.y + col1.z * col1.z);
-    let sz: real =
-        ComplexField::sqrt(col2.x * col2.x + col2.y * col2.y + col2.z * col2.z);
+    let sx: real = ComplexField::sqrt(col0.x * col0.x + col0.y * col0.y + col0.z * col0.z);
+    let sy: real = ComplexField::sqrt(col1.x * col1.x + col1.y * col1.y + col1.z * col1.z);
+    let sz: real = ComplexField::sqrt(col2.x * col2.x + col2.y * col2.y + col2.z * col2.z);
     // Detect negative scale via determinant sign
     let det = basis.determinant();
     if det < 0.0 {
@@ -230,11 +227,7 @@ pub fn transform_update(transform: &Transform, rotation: Rotation, origin: Vecto
     let col2 = Vector3::new(2.0 * (xz + wy), 2.0 * (yz - wx), 1.0 - 2.0 * (xx + yy));
     // Apply scale from the original transform deterministically
     let scale = transform_scale(transform);
-    let basis = godot::builtin::Basis::from_cols(
-        col0 * scale.x,
-        col1 * scale.y,
-        col2 * scale.z,
-    );
+    let basis = godot::builtin::Basis::from_cols(col0 * scale.x, col1 * scale.y, col2 * scale.z);
     Transform::new(basis, origin)
 }
 #[cfg(feature = "dim3")]
@@ -343,17 +336,15 @@ pub fn vector_normalized(vector: Vector) -> Vector {
     if vector != Vector::ZERO {
         #[cfg(feature = "dim2")]
         {
-            let len: real =
-                ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y);
+            let len: real = ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y);
             if len > 0.0 {
                 return Vector2::new(vector.x / len, vector.y / len);
             }
         }
         #[cfg(feature = "dim3")]
         {
-            let len: real = ComplexField::sqrt(
-                vector.x * vector.x + vector.y * vector.y + vector.z * vector.z,
-            );
+            let len: real =
+                ComplexField::sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z);
             if len > 0.0 {
                 return Vector3::new(vector.x / len, vector.y / len, vector.z / len);
             }


### PR DESCRIPTION
3D version of this plugin is not really cross deterministic even with enhanced-determinism flag for these reasons:
- Non cross platform deterministic math was used (sqrt, length, normalize, quaternion manipulations).
- Parry dependency coming from Rapier3D dependency also has a bug with 3D cross platform determinism.

What I did:
- Used only cross platform deterministic maths
- Added the glamx/scalar-math under the enhanced-determinism flag

_Note:_
_The glamx/scalar-math is only a temporary fix. It can be removed once the [Rapier](https://github.com/dimforge/rapier) repository includes the [Parry](https://github.com/dimforge/parry) dependency with this [fix](https://github.com/dimforge/parry/pull/426)._

- Fixes https://github.com/appsinacup/godot-rapier-physics/issues/562