### PR TITLE
Fix crash by cloning list so it doesn't clash while iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.8.37
+
+## What's Changed
+* Cross platform determinism tests by @RaphaelLEMAS in https://github.com/appsinacup/godot-rapier-physics/pull/561
+* enhanced-determinism feature does not guarantee cross-platform determinism for 3D by @RaphaelLEMAS in https://github.com/appsinacup/godot-rapier-physics/pull/564
+* use native quaternion manipulation instead of manually doing it by @RaphaelLEMAS in https://github.com/appsinacup/godot-rapier-physics/pull/565
+* Remove default features also so it's less confusing. by @Ughuuu in https://github.com/appsinacup/godot-rapier-physics/pull/566
+* Possible fixes to crash on reload of server  by @Ughuuu in https://github.com/appsinacup/godot-rapier-physics/pull/567
+* Fix crash by cloning list so it doesn't clash while iterating by @Ughuuu in https://github.com/appsinacup/godot-rapier-physics/pull/569
+
+
+**Full Changelog**: https://github.com/appsinacup/godot-rapier-physics/compare/v0.8.36...v0.8.37
+
 ## v0.8.36
 
 - Update to Godot 4.7 by @Ughuuu in https://github.com/appsinacup/godot-rapier-physics/pull/560

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "godot-rapier"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "bincode",
  "glamx",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-rapier"
-version = "0.8.36"
+version = "0.8.37"
 edition = "2024"
 license = "MIT"
 rust-version = "1.94"

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Exact simulation every time (on same platform)|Exact simulation on multiple plat
 
 # Installation
 
-- Automatic (Recommended): Download the plugin from the official [Godot Asset Store](https://godotengine.org/asset-library/asset/2267) using the `AssetLib` tab in Godot:
-    - [Rapier Physics 2D - Fast Version with Parallel SIMD Solver](https://godotengine.org/asset-library/asset/2267)
-    - [Rapier Physics 2D - Slower Version with Cross Platform Deterministic](https://godotengine.org/asset-library/asset/2815)
-    - [Rapier Physics 3D - Fast Version with Parallel SIMD Solver](https://godotengine.org/asset-library/asset/3084)
-    - [Rapier Physics 3D - Slower Version with Cross Platform Deterministic](https://godotengine.org/asset-library/asset/3085)
+- Automatic (Recommended): Download the plugin from the official [Godot Asset Store](https://store.godotengine.org) using the `Asset Store` tab in Godot:
+    - [Rapier Physics 2D - Fast Version with Parallel SIMD Solver](https://store.godotengine.org/asset/appsinacup/rapier-physics-2d-fast-version-with-parallel-simd-solver/)
+    - [Rapier Physics 2D - Slower Version with Cross Platform Deterministic](https://store.godotengine.org/asset/appsinacup/rapier-physics-2d-slower-version-with-cross-platform-deterministic/)
+    - [Rapier Physics 3D - Fast Version with Parallel SIMD Solver](https://store.godotengine.org/asset/appsinacup/rapier-physics-3d-fast-version-with-parallel-simd-solver/)
+    - [Rapier Physics 3D - Slower Version with Cross Platform Deterministic](https://store.godotengine.org/asset/appsinacup/rapier-physics-3d-slower-version-with-cross-platform-deterministic/)
 
     Note: For general use cases, use the **Faster Version**.
 
@@ -75,7 +75,7 @@ See [godot-rust/ExtensionLibrary](https://godot-rust.github.io/docs/gdext/master
 
 ```toml
 [dependencies]
-godot-rapier = { git = "https://github.com/appsinacup/godot-rapier-physics.git", tag = "v0.8.36", features = ["single-dim2"] }
+godot-rapier = { git = "https://github.com/appsinacup/godot-rapier-physics.git", tag = "v0.8.37", features = ["single-dim2"] }
 ```
 
 Feature sets matching the shipped addon variants:

--- a/bin2d/addons/godot-rapier2d/plugin.info.cfg
+++ b/bin2d/addons/godot-rapier2d/plugin.info.cfg
@@ -3,6 +3,6 @@
 name="Godot Rapier 2D"
 description="A 2D and 3D drop-in replacement for the Godot engine that adds stability and fluids."
 author="appsinacup"
-version="0.8.36"
+version="0.8.37"
 flavour="<flavour>"
 script=""

--- a/bin3d/addons/godot-rapier3d/plugin.info.cfg
+++ b/bin3d/addons/godot-rapier3d/plugin.info.cfg
@@ -3,6 +3,6 @@
 name="Godot Rapier 3D"
 description="A 2D and 3D drop-in replacement for the Godot engine that adds stability and fluids."
 author="appsinacup"
-version="0.8.36"
+version="0.8.37"
 flavour="<flavour>"
 script=""

--- a/src/bodies/rapier_body.rs
+++ b/src/bodies/rapier_body.rs
@@ -624,8 +624,8 @@ impl RapierBody {
         self.force_integration_callback = None;
         if callable.is_valid() {
             self.force_integration_callback = Some(callable);
-            if let Some(ds) = &self.direct_state {
-                self.force_integration_array.push(&ds.to_variant());
+            if let Some(direct_state) = self.direct_state_variant() {
+                self.force_integration_array.push(&direct_state);
                 if !udata.is_nil() {
                     self.force_integration_array.push(&udata);
                 }
@@ -650,16 +650,42 @@ impl RapierBody {
         self.force_integration_callback.as_ref()
     }
 
-    pub fn create_direct_state(&mut self) {
-        if self.direct_state.is_none() {
+    fn direct_state_variant(&mut self) -> Option<Variant> {
+        if self
+            .direct_state
+            .as_ref()
+            .is_some_and(|direct_state| direct_state.is_instance_valid())
+        {
+            return self
+                .direct_state
+                .as_ref()
+                .map(|direct_state| direct_state.to_variant());
+        }
+        if self.direct_state.is_some() {
+            self.direct_state = None;
             self.direct_state_array.clear();
-            let mut direct_space_state = RapierDirectBodyState::new_alloc();
-            {
-                let mut direct_state = direct_space_state.bind_mut();
-                direct_state.set_body(self.base.get_rid());
-            }
-            self.direct_state_array
-                .push(&direct_space_state.clone().to_variant());
+        }
+        None
+    }
+
+    pub fn create_direct_state(&mut self) {
+        if self
+            .direct_state
+            .as_ref()
+            .is_some_and(|direct_state| direct_state.is_instance_valid())
+        {
+            return;
+        }
+        self.direct_state = None;
+        self.direct_state_array.clear();
+        let mut direct_space_state = RapierDirectBodyState::new_alloc();
+        {
+            let mut direct_state = direct_space_state.bind_mut();
+            direct_state.set_body(self.base.get_rid());
+        }
+        if direct_space_state.is_instance_valid() {
+            let direct_state = direct_space_state.to_variant();
+            self.direct_state_array.push(&direct_state);
             self.direct_state = Some(direct_space_state.upcast());
         }
     }

--- a/src/bodies/rapier_direct_body_state_impl.rs
+++ b/src/bodies/rapier_direct_body_state_impl.rs
@@ -501,11 +501,9 @@ impl RapierDirectBodyStateImpl {
             if let Some(rid) = physics_data.ids.get(&rapier_id)
                 && let Some(collider_obj) = physics_data.collision_objects.get(rid)
             {
-                let instance_id = collider_obj.get_base().get_instance_id();
-                match Gd::try_from_instance_id(InstanceId::from_i64(instance_id as i64)) {
-                    Ok(object) => return Some(object),
-                    Err(_) => return None,
-                }
+                let instance_id =
+                    InstanceId::try_from_i64(collider_obj.get_base().get_instance_id() as i64)?;
+                return Gd::try_from_instance_id(instance_id).ok();
             }
         }
         None

--- a/src/fluids/fluid_3d.rs
+++ b/src/fluids/fluid_3d.rs
@@ -80,6 +80,9 @@ impl Fluid3D {
         let mut mm_inst = MultiMeshInstance3D::new_alloc();
         mm_inst.set_multimesh(Some(&mm));
         mm_inst.set_visible(true);
+        if !mm_inst.is_instance_valid() {
+            return;
+        }
         self.debug_multimesh = Some(mm);
         self.debug_multimesh_instance = Some(mm_inst.clone());
         let node_variant = mm_inst.clone().upcast::<Node>().to_variant();

--- a/src/spaces/rapier_direct_space_state_impl.rs
+++ b/src/spaces/rapier_direct_space_state_impl.rs
@@ -33,6 +33,12 @@ fn cross_product(a: Angle, b: Vector) -> Vector {
 fn cross_product(a: Angle, b: Vector) -> Vector {
     Vector::new(-a * b.y, a * b.x)
 }
+
+fn try_node_from_instance_id(instance_id: u64) -> Option<Gd<Node>> {
+    let instance_id = InstanceId::try_from_i64(instance_id as i64)?;
+    Gd::<Node>::try_from_instance_id(instance_id).ok()
+}
+
 impl RapierDirectSpaceStateImpl {
     #[cfg(feature = "dim3")]
     pub fn get_closest_point_to_object_volume(
@@ -151,10 +157,7 @@ impl RapierDirectSpaceStateImpl {
             if let Some(collision_object_2d) = physics_data.collision_objects.get(&result.rid) {
                 let instance_id = collision_object_2d.get_base().get_instance_id();
                 result.collider_id = ObjectId { id: instance_id };
-                if instance_id != 0
-                    && let Ok(object) =
-                        Gd::<Node>::try_from_instance_id(InstanceId::from_i64(instance_id as i64))
-                {
+                if let Some(object) = try_node_from_instance_id(instance_id) {
                     unsafe { result.set_collider(object) }
                 }
             }
@@ -242,10 +245,7 @@ impl RapierDirectSpaceStateImpl {
             result_slice.shape = shape_index as i32;
             let instance_id = collision_object_2d.get_base().get_instance_id();
             result_slice.collider_id = ObjectId { id: instance_id };
-            if instance_id != 0
-                && let Ok(object) =
-                    Gd::<Node>::try_from_instance_id(InstanceId::from_i64(instance_id as i64))
-            {
+            if let Some(object) = try_node_from_instance_id(instance_id) {
                 unsafe { result_slice.set_collider(object) }
             }
             output_count += 1;
@@ -321,10 +321,7 @@ impl RapierDirectSpaceStateImpl {
                 results_slice[cpt].rid = rid;
                 let instance_id = collision_object_2d.get_base().get_instance_id();
                 results_slice[cpt].collider_id = ObjectId { id: instance_id };
-                if instance_id != 0
-                    && let Ok(object) =
-                        Gd::<Node>::try_from_instance_id(InstanceId::from_i64(instance_id as i64))
-                {
+                if let Some(object) = try_node_from_instance_id(instance_id) {
                     unsafe { results_slice[cpt].set_collider(object) }
                 }
                 cpt += 1;

--- a/src/spaces/rapier_space.rs
+++ b/src/spaces/rapier_space.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use bodies::rapier_area::RapierArea;
 use bodies::rapier_body::RapierBody;
+use bodies::rapier_collision_object_base::CollisionObjectType;
 use godot::classes::ProjectSettings;
 #[cfg(feature = "dim2")]
 use godot::classes::physics_server_2d::*;
@@ -38,6 +39,31 @@ use crate::servers::rapier_physics_singleton::physics_data;
 use crate::servers::rapier_project_settings::*;
 use crate::types::*;
 use crate::*;
+
+enum PendingQueryCallback {
+    Callv {
+        callable: Callable,
+        args: VarArray,
+    },
+    Call {
+        callable: Callable,
+        args: Vec<Variant>,
+    },
+}
+
+impl PendingQueryCallback {
+    fn call(self) {
+        match self {
+            Self::Callv { callable, args } => {
+                callable.callv(&args);
+            }
+            Self::Call { callable, args } => {
+                callable.call(args.as_slice());
+            }
+        }
+    }
+}
+
 #[cfg(feature = "dim2")]
 const DEFAULT_GRAVITY_VECTOR: &str = "physics/2d/default_gravity_vector";
 #[cfg(feature = "dim3")]
@@ -163,55 +189,64 @@ impl RapierSpace {
     }
 
     #[inline]
-    fn call_body_state_query(
+    fn collect_body_state_query(
         body_id: RapierId,
         physics_collision_objects: &mut PhysicsCollisionObjects,
         physics_ids: &PhysicsIds,
-    ) {
+    ) -> Option<PendingQueryCallback> {
         let mut direct_state_array = None;
         let mut state_sync_callback = None;
         if let Some(body) = physics_collision_objects.get_mut(&get_id_rid(body_id, physics_ids))
             && let Some(body) = body.get_mut_body()
         {
             body.create_direct_state();
-            state_sync_callback = body.get_state_sync_callback();
-            direct_state_array = Some(body.get_direct_state_array());
+            state_sync_callback = body.get_state_sync_callback().cloned();
+            direct_state_array = Some(body.get_direct_state_array().clone());
         }
         if let Some(state_sync_callback) = state_sync_callback
             && let Some(direct_state_array) = direct_state_array
         {
-            state_sync_callback.callv(direct_state_array);
+            return Some(PendingQueryCallback::Callv {
+                callable: state_sync_callback,
+                args: direct_state_array,
+            });
         }
+        None
     }
 
     #[inline]
-    fn call_body_force_query(
+    fn collect_body_force_query(
         body_id: RapierId,
         physics_collision_objects: &mut PhysicsCollisionObjects,
         physics_ids: &PhysicsIds,
-    ) {
+    ) -> Option<PendingQueryCallback> {
         let mut fi_callback = None;
         let mut fi_array = None;
         if let Some(body) = physics_collision_objects.get_mut(&get_id_rid(body_id, physics_ids))
             && let Some(body) = body.get_mut_body()
         {
             body.create_direct_state();
-            fi_callback = body.get_force_integration_callable();
-            fi_array = Some(body.get_force_integration_array());
+            fi_callback = body.get_force_integration_callable().cloned();
+            fi_array = Some(body.get_force_integration_array().clone());
         }
         if let Some(fi_callback) = fi_callback
             && let Some(fi_array) = fi_array
         {
-            fi_callback.callv(fi_array);
+            return Some(PendingQueryCallback::Callv {
+                callable: fi_callback,
+                args: fi_array,
+            });
         }
+        None
     }
 
     #[inline]
-    fn call_body_state_and_force_queries(
+    fn collect_body_state_and_force_queries(
         body_id: RapierId,
         physics_collision_objects: &mut PhysicsCollisionObjects,
         physics_ids: &PhysicsIds,
-    ) {
+    ) -> Vec<PendingQueryCallback> {
+        let mut callbacks = Vec::new();
         let mut direct_state_array = None;
         let mut state_sync_callback = None;
         let mut fi_callback = None;
@@ -220,21 +255,28 @@ impl RapierSpace {
             && let Some(body) = body.get_mut_body()
         {
             body.create_direct_state();
-            state_sync_callback = body.get_state_sync_callback();
-            fi_callback = body.get_force_integration_callable();
-            direct_state_array = Some(body.get_direct_state_array());
-            fi_array = Some(body.get_force_integration_array());
+            state_sync_callback = body.get_state_sync_callback().cloned();
+            fi_callback = body.get_force_integration_callable().cloned();
+            direct_state_array = Some(body.get_direct_state_array().clone());
+            fi_array = Some(body.get_force_integration_array().clone());
         }
         if let Some(state_sync_callback) = state_sync_callback
             && let Some(direct_state_array) = direct_state_array
         {
-            state_sync_callback.callv(direct_state_array);
+            callbacks.push(PendingQueryCallback::Callv {
+                callable: state_sync_callback,
+                args: direct_state_array,
+            });
         }
         if let Some(fi_callback) = fi_callback
             && let Some(fi_array) = fi_array
         {
-            fi_callback.callv(fi_array);
+            callbacks.push(PendingQueryCallback::Callv {
+                callable: fi_callback,
+                args: fi_array,
+            });
         }
+        callbacks
     }
 
     #[inline]
@@ -257,7 +299,7 @@ impl RapierSpace {
         }
     }
 
-    pub fn call_queries(
+    fn collect_query_callbacks(
         active_list: &BTreeSet<RapierId>,
         deactivated_state_sync_list: &BTreeSet<RapierId>,
         state_query_list: &BTreeSet<RapierId>,
@@ -265,35 +307,52 @@ impl RapierSpace {
         monitor_query_list: &BTreeSet<RapierId>,
         physics_collision_objects: &mut PhysicsCollisionObjects,
         physics_ids: &PhysicsIds,
-    ) {
+    ) -> Vec<PendingQueryCallback> {
+        let mut callbacks = Vec::new();
         if !active_list.is_empty() && force_integrate_query_list.is_empty() {
             Self::for_each_intersection_body(active_list, state_query_list, |body_id| {
-                Self::call_body_state_query(body_id, physics_collision_objects, physics_ids);
+                if let Some(callback) =
+                    Self::collect_body_state_query(body_id, physics_collision_objects, physics_ids)
+                {
+                    callbacks.push(callback);
+                }
             });
         } else if !active_list.is_empty() && state_query_list.is_empty() {
             Self::for_each_intersection_body(active_list, force_integrate_query_list, |body_id| {
-                Self::call_body_force_query(body_id, physics_collision_objects, physics_ids);
+                if let Some(callback) =
+                    Self::collect_body_force_query(body_id, physics_collision_objects, physics_ids)
+                {
+                    callbacks.push(callback);
+                }
             });
         } else if !active_list.is_empty() {
             for body_id in active_list {
                 let state_query = state_query_list.contains(body_id);
                 let force_query = force_integrate_query_list.contains(body_id);
                 match (state_query, force_query) {
-                    (true, true) => Self::call_body_state_and_force_queries(
+                    (true, true) => callbacks.extend(Self::collect_body_state_and_force_queries(
                         *body_id,
                         physics_collision_objects,
                         physics_ids,
-                    ),
-                    (true, false) => Self::call_body_state_query(
-                        *body_id,
-                        physics_collision_objects,
-                        physics_ids,
-                    ),
-                    (false, true) => Self::call_body_force_query(
-                        *body_id,
-                        physics_collision_objects,
-                        physics_ids,
-                    ),
+                    )),
+                    (true, false) => {
+                        if let Some(callback) = Self::collect_body_state_query(
+                            *body_id,
+                            physics_collision_objects,
+                            physics_ids,
+                        ) {
+                            callbacks.push(callback);
+                        }
+                    }
+                    (false, true) => {
+                        if let Some(callback) = Self::collect_body_force_query(
+                            *body_id,
+                            physics_collision_objects,
+                            physics_ids,
+                        ) {
+                            callbacks.push(callback);
+                        }
+                    }
                     (false, false) => {}
                 }
             }
@@ -302,8 +361,14 @@ impl RapierSpace {
             deactivated_state_sync_list,
             state_query_list,
             |body_id| {
-                if !active_list.contains(&body_id) {
-                    Self::call_body_state_query(body_id, physics_collision_objects, physics_ids);
+                if !active_list.contains(&body_id)
+                    && let Some(callback) = Self::collect_body_state_query(
+                        body_id,
+                        physics_collision_objects,
+                        physics_ids,
+                    )
+                {
+                    callbacks.push(callback);
                 }
             },
         );
@@ -320,14 +385,54 @@ impl RapierSpace {
                 area_monitor_callback = area.area_monitor_callback.clone();
             }
             if let Some(unhandled_event_queue) = unhandled_event_queue {
-                RapierArea::call_queries(
-                    &unhandled_event_queue,
-                    monitor_callback,
-                    area_monitor_callback,
-                    physics_ids,
-                );
+                for monitor_report in unhandled_event_queue.values() {
+                    if monitor_report.state == 0 {
+                        godot_error!("Invalid monitor state");
+                        continue;
+                    }
+                    let rid = get_id_rid(monitor_report.id, physics_ids);
+                    let godot_instance_id: i64 = if let Some(obj_rid) =
+                        physics_ids.get(&monitor_report.instance_id)
+                        && let Some(obj) = physics_collision_objects.get(obj_rid)
+                    {
+                        obj.get_base().get_instance_id() as i64
+                    } else {
+                        0
+                    };
+                    let arg_array = if monitor_report.state > 0 {
+                        vec![
+                            AreaBodyStatus::ADDED.to_variant(),
+                            rid.to_variant(),
+                            godot_instance_id.to_variant(),
+                            monitor_report.object_shape_index.to_variant(),
+                            monitor_report.this_area_shape_index.to_variant(),
+                        ]
+                    } else {
+                        vec![
+                            AreaBodyStatus::REMOVED.to_variant(),
+                            rid.to_variant(),
+                            godot_instance_id.to_variant(),
+                            monitor_report.object_shape_index.to_variant(),
+                            monitor_report.this_area_shape_index.to_variant(),
+                        ]
+                    };
+                    if monitor_report.collision_object_type == CollisionObjectType::Body {
+                        if let Some(monitor_callback) = &monitor_callback {
+                            callbacks.push(PendingQueryCallback::Call {
+                                callable: monitor_callback.clone(),
+                                args: arg_array,
+                            });
+                        }
+                    } else if let Some(area_monitor_callback) = &area_monitor_callback {
+                        callbacks.push(PendingQueryCallback::Call {
+                            callable: area_monitor_callback.clone(),
+                            args: arg_array,
+                        });
+                    }
+                }
             }
         }
+        callbacks
     }
 
     pub fn update_after_queries(
@@ -614,32 +719,30 @@ impl RapierSpace {
     }
 
     pub fn flush(&mut self) {
-        let physics_data = physics_data();
-        {
-            let active_list = Some(self.get_state().get_active_list());
+        let callbacks = {
+            let physics_data = physics_data();
+            let physics_ids = physics_data.ids.clone();
+            let active_list = self.get_state().get_active_list().clone();
             let deactivated_state_sync_list =
-                Some(self.get_state().get_deactivated_state_sync_list());
-            let state_query_list = Some(self.get_state().get_state_query_list());
+                self.get_state().get_deactivated_state_sync_list().clone();
+            let state_query_list = self.get_state().get_state_query_list().clone();
             let force_integrate_query_list =
-                Some(self.get_state().get_force_integrate_query_list());
-            let monitor_query_list = Some(self.get_state().get_monitor_query_list());
-            if let Some(active_list) = active_list
-                && let Some(deactivated_state_sync_list) = deactivated_state_sync_list
-                && let Some(state_query_list) = state_query_list
-                && let Some(force_integrate_query_list) = force_integrate_query_list
-                && let Some(monitor_query_list) = monitor_query_list
-            {
-                RapierSpace::call_queries(
-                    active_list,
-                    deactivated_state_sync_list,
-                    state_query_list,
-                    force_integrate_query_list,
-                    monitor_query_list,
-                    &mut physics_data.collision_objects,
-                    &physics_data.ids,
-                );
-            }
+                self.get_state().get_force_integrate_query_list().clone();
+            let monitor_query_list = self.get_state().get_monitor_query_list().clone();
+            RapierSpace::collect_query_callbacks(
+                &active_list,
+                &deactivated_state_sync_list,
+                &state_query_list,
+                &force_integrate_query_list,
+                &monitor_query_list,
+                &mut physics_data.collision_objects,
+                &physics_ids,
+            )
+        };
+        for callback in callbacks {
+            callback.call();
         }
+        let physics_data = physics_data();
         self.get_mut_state().reset_deactivated_state_sync_list();
         self.update_after_queries(&mut physics_data.collision_objects, &physics_data.ids);
     }


### PR DESCRIPTION
By calling the callback in place, we are mutating the physics data, and can cause a crash. Release the mutable reference and clone the callbacks/args instead.

- Fixes https://github.com/appsinacup/godot-rapier-physics/issues/568
- Fixes https://github.com/appsinacup/godot-rapier-physics/issues/570