### PR TITLE
Change AccelerationBased springs to ForceBased

### DIFF
--- a/bin2d/samples/test_motor_position/test_motor_position.tscn
+++ b/bin2d/samples/test_motor_position/test_motor_position.tscn
@@ -1,9 +1,9 @@
 [gd_scene format=3 uid="uid://dufpjbflrebmt"]
 
-[ext_resource type="Script" uid="uid://de4wf7wb5aule" path="res://test_motor_position.gd" id="1_airgf"]
-[ext_resource type="Script" uid="uid://ch4e8om5vmkgs" path="res://test_motor_position_beam.gd" id="1_i7gvn"]
+[ext_resource type="Script" uid="uid://de4wf7wb5aule" path="res://samples/test_motor_position/test_motor_position.gd" id="1_airgf"]
+[ext_resource type="Script" uid="uid://ch4e8om5vmkgs" path="res://samples/test_motor_position/test_motor_position_beam.gd" id="1_i7gvn"]
 [ext_resource type="Script" uid="uid://unwhnooi7g2c" path="res://addons/godot-rapier2d/custom_nodes/rapier_rigid_body_2d.gd" id="2_airgf"]
-[ext_resource type="Script" uid="uid://bjckrk4dmnguh" path="res://test_motor_position_spawner.gd" id="3_qmxtd"]
+[ext_resource type="Script" uid="uid://bjckrk4dmnguh" path="res://samples/test_motor_position/test_motor_position_spawner.gd" id="3_qmxtd"]
 [ext_resource type="Script" uid="uid://bv2bc4lt5v7hu" path="res://addons/godot-rapier2d/custom_nodes/rapier_pin_joint_2d.gd" id="4_dnnds"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_rl7rh"]
@@ -59,8 +59,8 @@ motor_target_velocity = 1.5707964
 script = ExtResource("4_dnnds")
 motor_position_enabled = true
 motor_position_target_angle = -0.6492624817418904
-motor_position_stiffness = 1000.0
-motor_position_damping = 10.0
+motor_position_stiffness = 1000000.0
+motor_position_damping = 10000.0
 metadata/_custom_type_script = "uid://bv2bc4lt5v7hu"
 
 [node name="RapierRigidBody2D" type="RigidBody2D" parent="Lever" unique_id=1189770906]

--- a/bin2d/samples/test_motor_position/test_motor_position_beam.gd
+++ b/bin2d/samples/test_motor_position/test_motor_position_beam.gd
@@ -3,8 +3,8 @@
 extends StaticBody2D
 
 @export var number_of_segments : int = 10	
-@export var starting_stiffness: float = 100000.0
-@export var damping : float = 500.0
+@export var starting_stiffness: float = 100000000.0
+@export var damping : float = 2000000.0
 @export var segment_length : float = 100.0
 @export var starting_segment_height : float = 50.0
 @export var starting_segment_mass : float = 1.0

--- a/src/joints/rapier_revolute_joint.rs
+++ b/src/joints/rapier_revolute_joint.rs
@@ -32,8 +32,6 @@ pub struct RapierRevoluteJoint {
     motor_damping: f32,
     motor_position_enabled: bool,
     bias: f32,
-    #[cfg(feature = "dim3")]
-    motor_max_force: f32,
     base: RapierJointBase,
 }
 impl RapierRevoluteJoint {
@@ -98,6 +96,7 @@ impl RapierRevoluteJoint {
             0.0,
             0.0,
             false,
+            f32::MAX,
             true,
         );
         Self {
@@ -140,7 +139,6 @@ impl RapierRevoluteJoint {
             motor_stiffness: 0.0,
             motor_damping: 0.0,
             motor_position_enabled: false,
-            motor_max_force: 0.0,
             bias: 0.0,
             base: RapierJointBase::default(),
         };
@@ -192,7 +190,6 @@ impl RapierRevoluteJoint {
             motor_stiffness: 0.0,
             motor_damping: 0.0,
             motor_position_enabled: false,
-            motor_max_force: 0.0,
             bias: 0.0,
             base: RapierJointBase::new(id, rid, space_id, space_handle, handle, joint_type),
         }
@@ -236,6 +233,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
         );
@@ -273,10 +271,9 @@ impl RapierRevoluteJoint {
             motor_stiffness,
             motor_damping,
             motor_position_enabled,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
-            #[cfg(feature = "dim3")]
-            self.motor_max_force,
         );
     }
 
@@ -298,7 +295,8 @@ impl RapierRevoluteJoint {
                 self.motor_target_velocity = p_value;
             }
             physics_server_3d::HingeJointParam::MOTOR_MAX_IMPULSE => {
-                self.motor_max_force = p_value / Self::estimate_physics_step();
+                self.base
+                    .set_max_force(p_value / Self::estimate_physics_step());
             }
             _ => {}
         }
@@ -318,7 +316,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
-            self.motor_max_force,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
         );
@@ -358,6 +356,32 @@ impl RapierRevoluteJoint {
     }
 
     #[cfg(feature = "dim2")]
+    pub fn set_max_force(&mut self, force: f32, physics_engine: &mut PhysicsEngine) {
+        self.get_mut_base().set_max_force(force);
+
+        physics_engine.joint_change_revolute_params(
+            self.base.get_space_id(),
+            self.base.get_handle(),
+            self.angular_limit_lower,
+            self.angular_limit_upper,
+            self.angular_limit_enabled,
+            self.motor_target_velocity,
+            self.motor_enabled,
+            #[cfg(feature = "dim2")]
+            self.softness,
+            #[cfg(feature = "dim3")]
+            0.0,
+            self.motor_target_position,
+            self.motor_stiffness,
+            self.motor_damping,
+            self.motor_position_enabled,
+            self.base.get_max_force(),
+            self.get_final_bias(),
+            Self::estimate_physics_step(),
+        );
+    }
+
+    #[cfg(feature = "dim2")]
     pub fn set_bias_param(&mut self, value: f32, physics_engine: &mut PhysicsEngine) {
         self.bias = value;
         if !self.base.is_valid() {
@@ -379,8 +403,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
-            #[cfg(feature = "dim3")]
-            self.motor_max_force,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
         );
@@ -423,7 +446,7 @@ impl RapierRevoluteJoint {
             physics_server_3d::HingeJointParam::LIMIT_LOWER => self.angular_limit_lower,
             physics_server_3d::HingeJointParam::MOTOR_TARGET_VELOCITY => self.motor_target_velocity,
             physics_server_3d::HingeJointParam::MOTOR_MAX_IMPULSE => {
-                self.motor_max_force * Self::estimate_physics_step()
+                self.base.get_max_force() * Self::estimate_physics_step()
             }
             _ => 0.0,
         }
@@ -461,6 +484,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
         );
@@ -498,7 +522,7 @@ impl RapierRevoluteJoint {
             self.motor_stiffness,
             self.motor_damping,
             self.motor_position_enabled,
-            self.motor_max_force,
+            self.base.get_max_force(),
             self.get_final_bias(),
             Self::estimate_physics_step(),
         );

--- a/src/rapier_wrapper/joint.rs
+++ b/src/rapier_wrapper/joint.rs
@@ -1,6 +1,4 @@
 use godot::global::godot_error;
-#[cfg(feature = "dim2")]
-use rapier::na::ComplexField;
 use rapier::prelude::*;
 
 use crate::joints::rapier_joint_base::RapierJointType;
@@ -8,24 +6,6 @@ use crate::joints::rapier_joint_base::RapierJointType;
 use crate::rapier_wrapper::joint::glamx::Quat;
 use crate::rapier_wrapper::prelude::*;
 impl PhysicsEngine {
-    #[cfg(feature = "dim2")]
-    fn godot_spring_to_rapier_accel(stiffness: Real, damping: Real) -> (Real, Real) {
-        // Godot stiffness is in N/m, convert to frequency: omega = sqrt(k/m)
-        // For AccelerationBased, assume unit mass (m=1)
-        let omega: Real = ComplexField::sqrt(stiffness);
-        // Calculate damping ratio from Godot damping: zeta = c / (2 * sqrt(k*m))
-        // For unit mass: zeta = c / (2 * sqrt(k))
-        let damping_ratio = if stiffness > 0.0 {
-            damping / (2.0 * omega)
-        } else {
-            0.0
-        };
-        // Convert back to AccelerationBased stiffness/damping
-        let rapier_stiffness = omega * omega;
-        let rapier_damping = 2.0 * damping_ratio * omega;
-        (rapier_stiffness, rapier_damping)
-    }
-
     pub fn get_multibody_rigidbodies(
         &mut self,
         world_handle: WorldHandle,
@@ -143,6 +123,7 @@ impl PhysicsEngine {
         motor_stiffness: Real,
         motor_damping: Real,
         motor_position_enabled: bool,
+        motor_max_force: Real,
         disable_collision: bool,
     ) -> JointHandle {
         self.body_wake_up(world_handle, body_handle_1, false);
@@ -152,7 +133,7 @@ impl PhysicsEngine {
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
                 .contacts_enabled(!disable_collision)
-                .motor_max_force(Real::MAX)
+                .motor_max_force(motor_max_force)
                 .motor_model(MotorModel::ForceBased);
             if angular_limit_enabled {
                 joint = joint.limits([angular_limit_lower, angular_limit_upper]);
@@ -213,7 +194,7 @@ impl PhysicsEngine {
             if motor_enabled {
                 joint = joint
                     .motor_velocity(JointAxis::AngX, motor_target_velocity, 0.0)
-                    .motor_model(JointAxis::AngX, MotorModel::AccelerationBased)
+                    .motor_model(JointAxis::AngX, MotorModel::ForceBased)
                     .motor_max_force(JointAxis::AngX, motor_max_force);
             } else if motor_position_enabled {
                 joint = joint
@@ -224,7 +205,7 @@ impl PhysicsEngine {
                         motor_damping,
                     )
                     .motor_max_force(JointAxis::AngX, Real::MAX)
-                    .motor_model(JointAxis::AngX, MotorModel::AccelerationBased);
+                    .motor_model(JointAxis::AngX, MotorModel::ForceBased);
             }
             return physics_world.insert_joint(
                 body_handle_1,
@@ -348,16 +329,16 @@ impl PhysicsEngine {
         motor_stiffness: Real,
         motor_damping: Real,
         motor_position_enabled: bool,
+        motor_max_force: Real,
         bias: Real,
         physics_step: Real,
-        #[cfg(feature = "dim3")] motor_max_force: Real,
     ) {
         self.joint_wake_up_connected_rigidbodies(world_handle, joint_handle);
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
         {
-            joint.set_motor_model(JointAxis::AngX, MotorModel::AccelerationBased);
-            joint.set_motor_max_force(JointAxis::AngX, Real::MAX);
+            joint.set_motor_model(JointAxis::AngX, MotorModel::ForceBased);
+            joint.set_motor_max_force(JointAxis::AngX, motor_max_force);
             if angular_limit_enabled {
                 joint.set_limits(JointAxis::AngX, [angular_limit_lower, angular_limit_upper]);
             } else {
@@ -365,8 +346,6 @@ impl PhysicsEngine {
             }
             if motor_enabled {
                 joint.set_motor(JointAxis::AngX, 0.0, motor_target_velocity, 0.0, 0.0);
-                #[cfg(feature = "dim3")]
-                joint.set_motor_max_force(JointAxis::AngX, motor_max_force);
             } else if motor_position_enabled {
                 joint.set_motor(
                     JointAxis::AngX,
@@ -447,10 +426,8 @@ impl PhysicsEngine {
         self.body_wake_up(world_handle, body_handle_1, false);
         self.body_wake_up(world_handle, body_handle_2, false);
         if let Some(physics_world) = self.get_mut_world(world_handle) {
-            let (rapier_stiffness, rapier_damping) =
-                Self::godot_spring_to_rapier_accel(stiffness, damping);
-            let joint = SpringJointBuilder::new(rest_length, rapier_stiffness, rapier_damping)
-                .spring_model(MotorModel::AccelerationBased)
+            let joint = SpringJointBuilder::new(rest_length, stiffness, damping)
+                .spring_model(MotorModel::ForceBased)
                 .local_anchor1(anchor_1)
                 .local_anchor2(anchor_2)
                 .contacts_enabled(!disable_collision);
@@ -472,15 +449,8 @@ impl PhysicsEngine {
         if let Some(physics_world) = self.get_mut_world(world_handle)
             && let Some(joint) = physics_world.get_mut_joint(joint_handle)
         {
-            let (rapier_stiffness, rapier_damping) =
-                Self::godot_spring_to_rapier_accel(stiffness, damping);
-            joint.set_motor_position(
-                JointAxis::LinX,
-                rest_length,
-                rapier_stiffness,
-                rapier_damping,
-            );
-            joint.set_motor_model(JointAxis::LinX, MotorModel::AccelerationBased);
+            joint.set_motor_position(JointAxis::LinX, rest_length, stiffness, damping);
+            joint.set_motor_model(JointAxis::LinX, MotorModel::ForceBased);
         }
     }
 
@@ -685,7 +655,7 @@ impl PhysicsEngine {
                 joint.set_motor_max_force(axis, motor_force_limit);
                 joint.set_motor(axis, 0.0, motor_target_velocity, 0.0, 0.0);
             } else if enable_spring {
-                joint.set_motor_model(axis, MotorModel::AccelerationBased);
+                joint.set_motor_model(axis, MotorModel::ForceBased);
                 joint.set_motor(
                     axis,
                     spring_equilibrium_point,

--- a/src/servers/rapier_physics_server_impl.rs
+++ b/src/servers/rapier_physics_server_impl.rs
@@ -1702,8 +1702,16 @@ impl RapierPhysicsServerImpl {
         let physics_data = physics_data();
         if let Some(joint) = physics_data.joints.get_mut(&joint) {
             match param {
+                // TODO: This should just call a new set_param on an IRapierJoint function.
+                // The joint implementations need to know when params are changing so that they
+                // can reset the Rapier joint.
+                // For now, only the revolute joint is using these parameters, so explicit update functions
+                // have been added just to revolute joint to avoid refactoring RapierJointBase and RapierJoint.
                 JointParam::MAX_FORCE => {
                     joint.get_mut_base().set_max_force(value);
+                    if let RapierJoint::RapierRevoluteJoint(rev_joint) = joint {
+                        rev_joint.set_max_force(value, &mut physics_data.physics_engine);
+                    }
                 }
                 JointParam::BIAS => {
                     if let RapierJoint::RapierRevoluteJoint(rev_joint) = joint {


### PR DESCRIPTION
- Delete acceleration spring conversion function (unused)
- Add max_force setting to revolute joint (PinJoint2D) for 2D
- Merge 2D and 3D code in rapier_revolute_joint.rs to use base.max_force
- Update test_motor_position_sample with stronger stiffness and damping to account for ForceBased

This is a bug fix, because Godot is using Force Based parameters, while Rapier was using Acceleration Based, which means that Rapier (before this PR) was not a plug in replacement for Godot Physics or Jolt. Rapier was behaving differently when given the same stiffness and damping numbers (unless the mass was 1.0 and the joint was at the center of mass).

I believe no one has noticed because no one is using these features:
- DampedSpringJoint2D (Rapier now matches what Godot, but Godot is also buggy)
- RapierPinJoint2D motor position function (This is a new Rapier-only feature which is now force based)
- Generic6DOFJoint3D per axis spring functions (Rapier should now do the same thing Jolt does)

If someone is using these features in Rapier, then they will need to change their spring constants to work with ForceBased. In this way it is a breaking change for them.

In addition, there were a few springs that we were using internally that aren't exposed to the user (like the motor). These have been changed to ForceBased to be consistent, but should have no effect (since we are effectively using 'infinite' stiffness there).

