### PR TITLE
Call remove_collider for each attached collider in PhysicsWorld::remove_rigid_body

### DIFF
--- a/src/rapier_wrapper/physics_world.rs
+++ b/src/rapier_wrapper/physics_world.rs
@@ -482,12 +482,16 @@ impl PhysicsWorld {
             &mut self.physics_objects.collider_set,
             &mut self.physics_objects.impulse_joint_set,
             &mut self.physics_objects.multibody_joint_set,
-            true,
+            false,
         ) {
             self.physics_objects.removed_rigid_bodies_user_data.insert(
                 OrderedRigidBodyHandle::new(rigid_body_handle),
                 UserData::new(rigid_body.user_data),
             );
+            // remove the attached colliders separately so that their user data is stored
+            for collider in rigid_body.colliders() {
+                self.remove_collider(*collider);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #605 

While investigating this issue using the sample project, I tried logging the `CollisionEventInfo` for each incoming collision event.

I noticed that for some of the events caused by reparenting the RigidBody2D, one of the `user_data` fields was filled with `u64::MAX`. This was because `PhysicsWorld::get_collider_user_data()` was failing to retrieve the user data for one of the colliders so was returning `UserData::invalid_user_data()` instead.

The reason for this is that `PhysicsWorld::remove_rigid_body()` was removing the colliders attached to the rigidbody without storing their user data into `self.physics_objects.removed_colliders_user_data`.

This commit fixes that mistake and resolves the issue. 