### PR TITLE
scripts: support windows/cygwin

### DIFF
--- a/scripts/build-dev-2d-f64.sh
+++ b/scripts/build-dev-2d-f64.sh
@@ -1,12 +1,17 @@
 cargo fmt -- --config-path rustfmt.toml
-cargo clippy --fix --allow-dirty --features="double-dim2,serde-serialize,test,parallel,register-docs,api-4-7"
+FEATURES="double-dim2,serde-serialize,test,parallel,register-docs,api-4-7"
+cargo clippy --fix --allow-dirty --features="$FEATURES"
 if [ "${OSTYPE#darwin}" != "$OSTYPE" ]; then
-    cargo build --features="double-dim2,serde-serialize,test,parallel,register-docs,api-4-7"
+    cargo build --features="$FEATURES"
     echo "Running on macOS"
     rm -f bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/debug/libgodot_rapier.dylib bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
+elif [ "$OSTYPE" = "cygwin" ]; then
+    cargo build --features="$FEATURES" --target=x86_64-pc-windows-msvc
+    echo "Running on Windows"
+    cp target/x86_64-pc-windows-msvc/debug/godot_rapier.dll bin2d/addons/godot-rapier2d/bin/libgodot_rapier.windows.x86_64-pc-windows-msvc.dll
 else
-    cargo build --features="single-dim2,serde-serialize,test,register-docs,api-4-7" --target=x86_64-unknown-linux-gnu
+    cargo build --features="$FEATURES" --target=x86_64-unknown-linux-gnu
     echo "Running on Linux"
     cp target/x86_64-unknown-linux-gnu/debug/libgodot_rapier.so bin2d/addons/godot-rapier2d/bin/libgodot_rapier.linux.x86_64-unknown-linux-gnu.so
 fi

--- a/scripts/build-dev-2d-web.sh
+++ b/scripts/build-dev-2d-web.sh
@@ -1,13 +1,13 @@
 cargo fmt -- --config-path rustfmt.toml
-cargo clippy --fix --allow-dirty --features="single-dim2,serde-serialize,test,register-docs,api-4-7"
+FEATURES="experimental-wasm,single-dim2,serde-serialize,test,api-4-7"
+cargo clippy --fix --allow-dirty --features="$FEATURES"
 if [ "${OSTYPE#darwin}" != "$OSTYPE" ]; then
-    cargo build --features="experimental-wasm,single-dim2,serde-serialize,test,api-4-7" --target=wasm32-unknown-emscripten -Z build-std=std --verbose
+    cargo build --features="$FEATURES" --target=wasm32-unknown-emscripten -Z build-std=std --verbose
     echo "Running on macOS"
     rm -f bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/debug/libgodot_rapier.dylib bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/wasm32-unknown-emscripten/debug/godot_rapier.wasm bin2d/addons/godot-rapier2d/bin/godot_rapier.wasm
 else
-    cargo build --features="single-dim2,serde-serialize,test,register-docs,api-4-7" --target=x86_64-unknown-linux-gnu
-    echo "Running on Linux"
-    cp target/x86_64-unknown-linux-gnu/debug/libgodot_rapier.so bin2d/addons/godot-rapier2d/bin/libgodot_rapier.linux.x86_64-unknown-linux-gnu.so
+    echo "Unsupported. Use macOS for building wasm32-unknown-emscripten target."
+    exit 1
 fi

--- a/scripts/build-dev-2d.sh
+++ b/scripts/build-dev-2d.sh
@@ -1,13 +1,18 @@
 cargo fmt -- --config-path rustfmt.toml
 cargo clippy --fix --allow-dirty --features="single-dim2,serde-serialize,test,register-docs,api-4-7"
+FEATURES="single-dim2,serde-serialize,test,register-docs,api-4-7"
 if [ "${OSTYPE#darwin}" != "$OSTYPE" ]; then
-    cargo build --features="single-dim2,serde-serialize,test,register-docs,api-4-7" # --verbose
+    cargo build --features="$FEATURES" # --verbose
     echo "Running on macOS"
     rm -f bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/debug/libgodot_rapier.dylib bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/debug/libgodot_rapier.a bin2d/addons/godot-rapier2d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.a
+elif [ "$OSTYPE" = "cygwin" ]; then
+    cargo build --features="$FEATURES" --target=x86_64-pc-windows-msvc
+    echo "Running on Windows"
+    cp target/x86_64-pc-windows-msvc/debug/godot_rapier.dll bin2d/addons/godot-rapier2d/bin/libgodot_rapier.windows.x86_64-pc-windows-msvc.dll
 else
-    cargo build --features="single-dim2,serde-serialize,test,register-docs,api-4-7" --target=x86_64-unknown-linux-gnu
+    cargo build --features="$FEATURES" --target=x86_64-unknown-linux-gnu
     echo "Running on Linux"
     cp target/x86_64-unknown-linux-gnu/debug/libgodot_rapier.so bin2d/addons/godot-rapier2d/bin/libgodot_rapier.linux.x86_64-unknown-linux-gnu.so
 fi

--- a/scripts/build-dev-3d.sh
+++ b/scripts/build-dev-3d.sh
@@ -1,12 +1,17 @@
 cargo fmt -- --config-path rustfmt.toml
-cargo clippy --fix --allow-dirty --features="single-dim3,serde-serialize,test,register-docs,api-4-7"
+FEATURES="single-dim3,serde-serialize,test,register-docs,api-4-7"
+cargo clippy --fix --allow-dirty --features="$FEATURES"
 if [ "${OSTYPE#darwin}" != "$OSTYPE" ]; then
-    cargo build --features="single-dim3,serde-serialize,test,register-docs,api-4-7"
+    cargo build --features="$FEATURES"
     echo "Running on macOS"
     rm -f bin3d/addons/godot-rapier3d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
     cp target/debug/libgodot_rapier.dylib bin3d/addons/godot-rapier3d/bin/libgodot_rapier.macos.framework/libgodot_rapier.macos.dylib
+elif [ "$OSTYPE" = "cygwin" ]; then
+    cargo build --features="$FEATURES" --target=x86_64-pc-windows-msvc
+    echo "Running on Windows"
+    cp target/x86_64-pc-windows-msvc/debug/godot_rapier.dll bin3d/addons/godot-rapier3d/bin/libgodot_rapier.windows.x86_64-pc-windows-msvc.dll
 else
-    cargo build --features="single-dim3,serde-serialize,test,register-docs,api-4-7" --target=x86_64-unknown-linux-gnu
+    cargo build --features="$FEATURES" --target=x86_64-unknown-linux-gnu
     echo "Running on Linux"
     cp target/x86_64-unknown-linux-gnu/debug/libgodot_rapier.so bin3d/addons/godot-rapier3d/bin/libgodot_rapier.linux.x86_64-unknown-linux-gnu.so
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,10 +7,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Linux: Use the 'godot' command assuming it's in the PATH or defined by an alias
     GODOT="godot"
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+    GODOT="godot"
 else
     echo "Unsupported OS: $OSTYPE"
     exit 1
 fi
 
 # Run the 2D regression test runner. The scene exits with a non-zero status on regressions.
-"$GODOT" --headless --path ./bin2d start.tscn
+"$GODOT" --headless --path ./bin2d --scene start.tscn


### PR DESCRIPTION
cygwin ships with Git for Windows, so most Windows dev machines should have this.

I considered rewriting the scripts to use a command runner like casey/just or cargo-make, but tbh this suffices.

- For the web-wasm script I removed the Linux path as it seems to have not actually build a wasm target.
- The test.sh script seems to have been broken without the --scene parameter. Maybe the Godot CLI changed over time here.