### PR TITLE
test: add test for fluid data having the same length

### DIFF
--- a/bin2d/tests/nodes/Fluid/fluid_2d.tscn
+++ b/bin2d/tests/nodes/Fluid/fluid_2d.tscn
@@ -2,8 +2,11 @@
 
 [ext_resource type="Script" uid="uid://bnjyhmyy8iy0o" path="res://base/class/test_scene_child.gd" id="1_m1km4"]
 [ext_resource type="PackedScene" uid="uid://b48od3a28mtso" path="res://tests/nodes/Fluid/tests/collision_detection.tscn" id="2_qjk6k"]
+[ext_resource type="PackedScene" uid="uid://c5gcp1vsswiri" path="res://tests/nodes/Fluid/tests/iterate_on_data.tscn" id="3_g08ej"]
 
 [node name="fluid_2d" type="Node2D" unique_id=1224020166]
 script = ExtResource("1_m1km4")
 
 [node name="collision_detection" parent="." unique_id=1783469513 instance=ExtResource("2_qjk6k")]
+
+[node name="iterate_on_data" parent="." unique_id=928729618 instance=ExtResource("3_g08ej")]

--- a/bin2d/tests/nodes/Fluid/tests/iterate_on_data.gd
+++ b/bin2d/tests/nodes/Fluid/tests/iterate_on_data.gd
@@ -1,0 +1,29 @@
+extends PhysicsUnitTest2D
+
+func test_description() -> String:
+  return &"Checks that [Faucet2D] fluids can iterate on their data"
+
+func test_name() -> String:
+  return &"Faucet2D | access metadata"
+
+func test_start() -> void:
+
+  var check:= func(fluid: Faucet2D, monitor: Monitor):
+    var positions := fluid.points
+    var accelerations := fluid.get_accelerations()
+    var velocities := fluid.get_velocities()
+    var remaining_lifetimes := fluid.get_remaining_times()
+    
+    if positions.size() != accelerations.size():
+      monitor.failed("The number of positions (%d) is different from the number of accelerations (%d)" % [positions.size(), accelerations.size()])
+      return
+    
+    if positions.size() != velocities.size():
+      monitor.failed("The number of positions (%d) is different from the number of velocities (%d)" % [positions.size(), velocities.size()])
+      return
+
+    if positions.size() != remaining_lifetimes.size():
+      monitor.failed("The number of positions (%d) is different from the number of remaining lifetimes (%d)" % [positions.size(), remaining_lifetimes.size()])
+      return
+    
+  self.create_generic_manual_monitor($Faucet2D, check, 5, false)

--- a/bin2d/tests/nodes/Fluid/tests/iterate_on_data.gd.uid
+++ b/bin2d/tests/nodes/Fluid/tests/iterate_on_data.gd.uid
@@ -1,0 +1,1 @@
+uid://dw02uitv0b86o

--- a/bin2d/tests/nodes/Fluid/tests/iterate_on_data.tscn
+++ b/bin2d/tests/nodes/Fluid/tests/iterate_on_data.tscn
@@ -1,0 +1,15 @@
+[gd_scene format=3 uid="uid://c5gcp1vsswiri"]
+
+[ext_resource type="Script" uid="uid://dw02uitv0b86o" path="res://tests/nodes/Fluid/tests/iterate_on_data.gd" id="1_6khp1"]
+[ext_resource type="Script" uid="uid://d4kq5akkly15i" path="res://addons/godot-rapier2d/faucet_2d.gd" id="2_45r3w"]
+
+[node name="iterate_on_data" type="Node2D" unique_id=928729618]
+script = ExtResource("1_6khp1")
+metadata/_custom_type_script = "uid://rif6b2kxe37h"
+
+[node name="Faucet2D" type="Fluid2D" parent="." unique_id=1870455752]
+debug_draw = true
+lifetime = 1.0
+position = Vector2(5, 5)
+script = ExtResource("2_45r3w")
+metadata/_custom_type_script = "uid://d4kq5akkly15i"

--- a/src/fluids/fluid_impl.rs
+++ b/src/fluids/fluid_impl.rs
@@ -72,13 +72,12 @@ impl FluidImpl {
 
     pub fn get_remaining_times(fluid: &Fluid) -> PackedFloat32Array {
         let ticks = Time::singleton().get_ticks_msec() as f32;
-        let mut remaining_times = PackedFloat32Array::default();
-        remaining_times.resize(fluid.create_times.len());
-        let div_1000 = 1.0 / 1000.0;
-        for i in 0..fluid.create_times.len() {
-            remaining_times[i] = (ticks - fluid.create_times[i]) * div_1000;
-        }
-        remaining_times
+        fluid
+            .create_times
+            .as_slice()
+            .iter()
+            .map(|&create_time| (ticks - create_time) * (1.0 / 1000.0))
+            .collect()
     }
 
     pub fn get_velocities(fluid: &Fluid) -> PackedVectorArray {


### PR DESCRIPTION
I've run into an issue where the remaining time array seems to have a different length than the other data buffers (meaning that some points seem to have no time associated with them).

I had a look at the code, but I couldn't spot any obvious place where the length of the points array is changed, but time array isn't kept in synch.